### PR TITLE
Fix false syntax errors when using `delete`

### DIFF
--- a/common/src/main/java/dev/latvian/mods/rhino/Token.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/Token.java
@@ -247,7 +247,7 @@ public interface Token {
 			case POS -> "POS";
 			case NEG -> "NEG";
 			case NEW -> "NEW";
-			case DELPROP -> "DELPROP";
+			case DELPROP -> "DELETE";
 			case TYPEOF -> "TYPEOF";
 			case GETPROP -> "GETPROP";
 			case GETPROPNOWARN -> "GETPROPNOWARN";

--- a/common/src/main/java/dev/latvian/mods/rhino/TokenStream.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/TokenStream.java
@@ -48,7 +48,7 @@ class TokenStream {
 			case "const" -> Token.CONST;
 			case "continue" -> Token.CONTINUE;
 			case "default" -> Token.DEFAULT;
-			case "delprop" -> Token.DELPROP;
+			case "delete" -> Token.DELPROP;
 			case "do" -> Token.DO;
 			case "else" -> Token.ELSE;
 			case "finally" -> Token.FINALLY;

--- a/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
+++ b/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
@@ -11,6 +11,11 @@ public class MiscTests {
 	public static final RhinoTest TEST = new RhinoTest("misc").shareScope();
 
 	@Test
+	public void testDelete() {
+		TEST.test("delete", "let x = {a: 1}; delete x.a; console.info(x.a);", "undefined");
+	}
+
+	@Test
 	@Order(1)
 	public void init() {
 		TEST.test("init", """


### PR DESCRIPTION
The keyword is not ``delprop``. It has never been ``delprop``.