### PR TITLE
Fix prototype ID super calls

### DIFF
--- a/common/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
@@ -537,7 +537,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
 			case "apply" -> Id_apply;
 			case "call" -> Id_call;
 			case "bind" -> Id_bind;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeDate.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeDate.java
@@ -1851,7 +1851,7 @@ final class NativeDate extends IdScriptableObject {
 			case "setYear" -> Id_setYear;
 			case "toISOString" -> Id_toISOString;
 			case "toJSON" -> Id_toJSON;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeError.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeError.java
@@ -322,7 +322,7 @@ final class NativeError extends IdScriptableObject {
 			case "constructor" -> Id_constructor;
 			case "toString" -> Id_toString;
 			case "toSource" -> Id_toSource;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
@@ -438,7 +438,7 @@ public final class NativeJSON extends IdScriptableObject {
 			case "toSource" -> Id_toSource;
 			case "parse" -> Id_parse;
 			case "stringify" -> Id_stringify;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeNumber.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeNumber.java
@@ -339,7 +339,7 @@ final class NativeNumber extends IdScriptableObject {
 			case "toFixed" -> Id_toFixed;
 			case "toExponential" -> Id_toExponential;
 			case "toPrecision" -> Id_toPrecision;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeString.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeString.java
@@ -1245,7 +1245,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 			case "padEnd" -> Id_padEnd;
 			case "trimStart" -> Id_trimStart;
 			case "trimEnd" -> Id_trimEnd;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeWeakMap.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeWeakMap.java
@@ -179,7 +179,7 @@ public class NativeWeakMap extends IdScriptableObject {
 			case "get" -> Id_get;
 			case "has" -> Id_has;
 			case "set" -> Id_set;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/rhino/NativeWeakSet.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeWeakSet.java
@@ -157,7 +157,7 @@ public class NativeWeakSet extends IdScriptableObject {
 			case "add" -> Id_add;
 			case "delete" -> Id_delete;
 			case "has" -> Id_has;
-			default -> super.findPrototypeId(s);
+			default -> 0;
 		};
 	}
 

--- a/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
+++ b/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
@@ -10,7 +10,17 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class MiscTests {
 	public static final RhinoTest TEST = new RhinoTest("misc").shareScope();
 
-	@Test
+	public void testFunctionAssignment() {
+		TEST.test("functionAssignment",
+				"""
+						let x = () => {};
+						x.abc = 1;
+						console.info(x.abc);
+						""",
+				"1.0"
+		);
+	}
+
 	@Order(1)
 	public void init() {
 		TEST.test("init", """


### PR DESCRIPTION
The super calls prevented assigning to arbitrary values on e.g. functions (which is used by some polyfills) as it would throw an error. Note that only *some* classes had the super call, whereas the others returned 0; I assume that this was inserted during a reformat commit a few years ago as upstream returns zero for all of them.