### PR TITLE
Fix JSON.stringify with nested arrays.

### DIFF
--- a/common/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
@@ -237,9 +237,9 @@ public final class NativeJSON extends IdScriptableObject {
 
 			for (Object o : (Iterable<?>) v) {
 				json.add(stringify0(cx, remapper, o));
-
-				return json;
 			}
+
+			return json;
 		}
 
 		if (v instanceof Wrapper) {

--- a/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
+++ b/common/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
@@ -141,4 +141,12 @@ public class MiscTests {
 				wood#0037c6ad
 				""");
 	}
+
+	@Test
+	public void testJsonStringifyWithNestedArrays() {
+		TEST.test("jsonStringifyWithNestedArrays", """
+				const thing = {nested: [1, 2, 3]};
+				console.info(JSON.stringify(thing));
+				""", "{\"nested\":[1.0,2.0,3.0]}");
+	}
 }


### PR DESCRIPTION
This was a simple mis-indent. This bit me multiple times when debugging custom recipes as it would only print one item in the array.