### PR TITLE
Fixed some general concurrency issue

### DIFF
--- a/common/src/main/java/dev/latvian/mods/rhino/ArrowFunction.java
+++ b/common/src/main/java/dev/latvian/mods/rhino/ArrowFunction.java
@@ -37,7 +37,7 @@ public class ArrowFunction extends BaseFunction {
 	}
 
 	@Override
-	public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+	public synchronized Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
 		Scriptable callThis = boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
 		return targetFunction.call(cx, scope, callThis, args);
 	}


### PR DESCRIPTION
Due to how REI and other mods work sometimes they gives IllegalStatementException randomly.
This fix solves, at least, all one that I have currently (GregTech, REI, and some ForgeEvents)

Example script below is a good benchmark for being very intense and using REI because they use multiple threads to cache
```js
StartupEvents.postInit(e => {
  if (Platform.isClientEnvironment()){
    // KubeJS Priority is not enough for some cases, setting a custom to be lower.
    ForgeEvents.eventBus().addListener("lowest", false, Java.loadClass("net.minecraftforge.event.entity.player.ItemTooltipEvent"), (/** @type {Internal.ItemTooltipEvent}*/ event) => {
      let dummyLet
      const dummyConst = 69
      const dummyString = "Noice"
      const dummyAssign = event.toolTip.get(0)
      event.toolTip.set(event.toolTip.size() - 1, Text.red("Yoink =)"))
      dummyLet = () => {return 200}
    })
  }
})
```
This script causes A TON of errors like below:
```
[09Dec2023 09:11:14.368] [REI-Cache-1/ERROR] [net.minecraftforge.eventbus.EventBus/EVENTBUS]: Exception caught during firing event: null
	Index: 7
	Listeners:
		0: HIGH
		1: ASM: class dev.architectury.event.forge.EventHandlerImplClient event(Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;)V
		2: NORMAL
		3: ASM: class com.simibubi.create.foundation.events.ClientEvents addToItemTooltip(Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;)V
		4: net.minecraftforge.eventbus.EventBus$$Lambda$4700/0x000000080185e6e8@1375184
		5: ASM: class com.gregtechceu.gtceu.client.forge.ForgeClientEventListener onTooltipEvent(Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;)V
		6: LOW
		7: net.minecraftforge.eventbus.EventBus$$Lambda$4700/0x000000080185e6e8@7a5d226e
		8: LOWEST
		9: net.minecraftforge.eventbus.EventBus$$Lambda$4700/0x000000080185e6e8@6b2aac4b
java.lang.IllegalStateException
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.ScriptRuntime.doTopCall(ScriptRuntime.java:2628)
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.InterpretedFunction.call(InterpretedFunction.java:70)
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.ArrowFunction.call(ArrowFunction.java:42)
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.InterfaceAdapter.invokeImpl(InterfaceAdapter.java:129)
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.InterfaceAdapter.invoke(InterfaceAdapter.java:88)
	at TRANSFORMER/rhino@2001.2.2-local.1702123042/dev.latvian.mods.rhino.VMBridge.lambda$newInterfaceProxy$0(VMBridge.java:74)
	at jdk.proxy1/jdk.proxy1.$Proxy77.accept(Unknown Source)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:260)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:252)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
	at TRANSFORMER/forge@47.1.3/net.minecraftforge.event.ForgeEventFactory.onItemTooltip(ForgeEventFactory.java:358)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.item.ItemStack.m_41651_(ItemStack.java:763)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.plugin.client.entry.ItemEntryDefinition.tryGetItemStackToolTip(ItemEntryDefinition.java:231)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.plugin.client.entry.ItemEntryDefinition$ItemEntryRenderer.getTooltip(ItemEntryDefinition.java:369)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.common.entry.AbstractEntryStack.getTooltip(AbstractEntryStack.java:195)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.client.search.argument.type.TooltipArgumentType.tryGetEntryStackTooltip(TooltipArgumentType.java:90)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.client.search.argument.type.TooltipArgumentType.cacheData(TooltipArgumentType.java:75)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.client.search.argument.type.TooltipArgumentType.cacheData(TooltipArgumentType.java:45)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.client.search.argument.ArgumentCache.cacheStacks(ArgumentCache.java:138)
	at TRANSFORMER/roughlyenoughitems@12.0.665/me.shedaniel.rei.impl.client.search.argument.ArgumentCache.lambda$cache$1(ArgumentCache.java:110)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

With this fix the error is gone and code works perfectly.