### PR TITLE
Made `VariableTypeInfo` more usable for type dumpers

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
@@ -28,7 +28,7 @@ public class VariableTypeInfo extends TypeInfoBase {
 	 * Variable name is needed for type dumping purpose, otherwise I still need
 	 * to create a resolver completely parallel to {@link dev.latvian.mods.rhino.type.TypeInfo#of(Class)}
 	 */
-    private final String name;
+	private final String name;
 
 	public VariableTypeInfo(String name) {
 		this.name = name;
@@ -43,19 +43,9 @@ public class VariableTypeInfo extends TypeInfoBase {
 			// a variable type can have multiple bounds, but we only resolves the first one, since type wrapper cannot
 			// magically find or create a class that meets multiple bounds
 			Type bound = t.getBounds()[0];
-			if (bound == Object.class) {
-				CACHE.put(t, got = TypeInfo.NONE);
-			} else {
-				VariableTypeInfo variable = new VariableTypeInfo(t.getName());
-				CACHE.put(t, got = variable);
-				/*
-				 * we cannot create VariableTypeInfo directly, because types like {@code Enum<T extends Enum<T>>} will
-				 * cause TypeInfo.of() to parse the same variable type `T` infinitely, instead we push it into cache
-				 * before next TypeInfo.of(...) call to make sure that `T` in `Enum<T>` in `T extends Enum<T>` is
-				 * already parsed, so that we can break the loop
-				 */
-				variable.consolidated = TypeInfo.of(bound);
-			}
+			VariableTypeInfo variable = new VariableTypeInfo(t.getName());
+			CACHE.put(t, got = variable);
+			variable.consolidated = TypeInfo.of(bound);
 			WRITE.unlock();
 		}
 		return got;
@@ -66,7 +56,7 @@ public class VariableTypeInfo extends TypeInfoBase {
 		return consolidated.asClass();
 	}
 
-	public String getName(){
+	public String getName() {
 		return name;
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
@@ -9,6 +9,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author ZZZank
+ * @author Prunoideae
  */
 public class VariableTypeInfo extends TypeInfoBase {
 	private static final Map<TypeVariable<?>, TypeInfo> CACHE = new HashMap<>();
@@ -24,9 +25,15 @@ public class VariableTypeInfo extends TypeInfoBase {
 	private TypeInfo consolidated = null;
 
 	/**
-	 * we don't need type name to match a TypeVariable, it's designed to be unique
+	 * Variable name is needed for type dumping purpose, otherwise I still need
+	 * to create a resolver completely parallel to {@link dev.latvian.mods.rhino.type.TypeInfo#of(Class)}
 	 */
-//    private final String name;
+    private final String name;
+
+	public VariableTypeInfo(String name) {
+		this.name = name;
+	}
+
 	static TypeInfo of(TypeVariable<?> t) {
 		READ.lock();
 		var got = CACHE.get(t);
@@ -39,7 +46,7 @@ public class VariableTypeInfo extends TypeInfoBase {
 			if (bound == Object.class) {
 				CACHE.put(t, got = TypeInfo.NONE);
 			} else {
-				VariableTypeInfo variable = new VariableTypeInfo();
+				VariableTypeInfo variable = new VariableTypeInfo(t.getName());
 				CACHE.put(t, got = variable);
 				/*
 				 * we cannot create VariableTypeInfo directly, because types like {@code Enum<T extends Enum<T>>} will
@@ -57,5 +64,9 @@ public class VariableTypeInfo extends TypeInfoBase {
 	@Override
 	public Class<?> asClass() {
 		return consolidated.asClass();
+	}
+
+	public String getName(){
+		return name;
 	}
 }


### PR DESCRIPTION
Added type name to `VariableTypeInfo`, and also made the `VariableTypeInfo.of` always return `VariableTypeInfo` instead of `TypeInfo.NONE` when there's no bound present.

This is mainly for type dumping purpose, performance impact introduce by this PR should be minimal.