### PR TITLE
Full Java Generics supports

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/CachedExecutableInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/CachedExecutableInfo.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.rhino;
 
+import dev.latvian.mods.rhino.type.TypeConsolidator;
 import dev.latvian.mods.rhino.type.TypeInfo;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,6 +63,8 @@ public class CachedExecutableInfo extends CachedMemberInfo {
 			} else if (ti.length == 0 && !varArgs) {
 				v = parameters = CachedParameters.EMPTY;
 			} else {
+				//first type consolidation, to remove type variables from super classes/interfaces
+				ti = TypeConsolidator.consolidateAll(ti, TypeConsolidator.getMapping(this.parent.type));
 				v = parameters = new CachedParameters(tc.length, List.of(tc), List.of(ti), fcx, varArgs ? ti[ti.length - 1].componentType() : null);
 			}
 		}

--- a/src/main/java/dev/latvian/mods/rhino/CachedFieldInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/CachedFieldInfo.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.rhino;
 
+import dev.latvian.mods.rhino.type.TypeConsolidator;
 import dev.latvian.mods.rhino.type.TypeInfo;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,7 +44,8 @@ public class CachedFieldInfo extends CachedMemberInfo {
 
 	public TypeInfo getType() {
 		if (type == null) {
-			type = TypeInfo.safeOf(field::getGenericType);
+			type = TypeInfo.safeOf(field::getGenericType)
+				.consolidate(TypeConsolidator.getMapping(this.parent.type));
 		}
 
 		return type;

--- a/src/main/java/dev/latvian/mods/rhino/CachedMethodInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/CachedMethodInfo.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.rhino;
 
+import dev.latvian.mods.rhino.type.TypeConsolidator;
 import dev.latvian.mods.rhino.type.TypeInfo;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,7 +48,8 @@ public class CachedMethodInfo extends CachedExecutableInfo {
 	@Override
 	public TypeInfo getReturnType() {
 		if (returnType == null) {
-			returnType = TypeInfo.safeOf(method::getGenericReturnType);
+			returnType = TypeInfo.safeOf(method::getGenericReturnType)
+				.consolidate(TypeConsolidator.getMapping(this.parent.type));
 		}
 
 		return returnType;

--- a/src/main/java/dev/latvian/mods/rhino/JavaMembers.java
+++ b/src/main/java/dev/latvian/mods/rhino/JavaMembers.java
@@ -305,10 +305,13 @@ public class JavaMembers {
 				throw Context.throwAsScriptRuntimeEx(new IllegalAccessException("Can't modify final field " + fieldInfo.getName()), cx);
 			}
 
-			// This definitely could use some cache
-			Object javaValue = cx.jsToJava(value, fieldInfo.getType());
+			var type = fieldInfo.getType();
+			if (scope instanceof NativeJavaObject nativeJavaObject) {
+				type = type.consolidate(nativeJavaObject.getTypeMapping());
+			}
+
 			try {
-				fieldInfo.set(cx, javaObject, javaValue);
+				fieldInfo.set(cx, javaObject, cx.jsToJava(value, type));
 			} catch (IllegalArgumentException argEx) {
 				throw Context.reportRuntimeError3("msg.java.internal.field.type", value.getClass().getName(), fieldInfo.getType(), javaObject.getClass().getName(), cx);
 			} catch (Throwable accessEx) {

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaMethod.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaMethod.java
@@ -349,30 +349,9 @@ public class NativeJavaMethod extends BaseFunction {
 
 		var argTypes = pars.typeInfos();
 
-		/**
-		 *
-		 * the argTypes are already 'flattened' the type variable used by the current class, so here
-		 * we only need to convert type variables of current class to the actual type.
-		 *
-		 * for example, an object is previously obtained via "public A<String> getA();" method, where
-		 * the A is "class A<T1> { ... }". Then we only need to use mapping 'T1 -> String' to convert
-		 * argTypes once
-		 */
 		if (thisObj instanceof NativeJavaObject nativeJavaObject
-			&& nativeJavaObject.typeInfo instanceof ParameterizedTypeInfo parameterized) {
-			var parameters = parameterized.asClass().getTypeParameters();
-			if (parameters.length == 1) {
-				argTypes = TypeConsolidator.consolidateAll(
-					argTypes,
-					Collections.singletonMap(TypeInfo.of(parameters[0]), parameterized.param(0))
-				);
-			} else {
-				var mapping = ImmutableMap.<VariableTypeInfo, TypeInfo>builder();
-				for (int i = 0, size = parameters.length; i < size; i++) {
-					mapping.put(TypeInfo.of(parameters[i]), parameterized.param(i));
-				}
-				argTypes = TypeConsolidator.consolidateAll(argTypes, mapping.build());
-			}
+			&& nativeJavaObject.typeInfo instanceof ParameterizedTypeInfo ignored) {
+			argTypes = TypeConsolidator.consolidateAll(argTypes, nativeJavaObject.getTypeMapping());
 		}
 
 		if (pars.isVarArg()) {

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaMethod.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaMethod.java
@@ -6,14 +6,11 @@
 
 package dev.latvian.mods.rhino;
 
-import com.google.common.collect.ImmutableMap;
 import dev.latvian.mods.rhino.type.ParameterizedTypeInfo;
 import dev.latvian.mods.rhino.type.TypeConsolidator;
 import dev.latvian.mods.rhino.type.TypeInfo;
-import dev.latvian.mods.rhino.type.VariableTypeInfo;
 
 import java.lang.reflect.Array;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -431,11 +428,14 @@ public class NativeJavaMethod extends BaseFunction {
 		}
 
 		Object retval = meth.invoke(javaObject, args, cx, scope);
-		var staticType = meth.getReturnType();
+		var returnType = meth.getReturnType();
+		if (thisObj instanceof NativeJavaObject nativeJavaObject) {
+			returnType = returnType.consolidate(nativeJavaObject.getTypeMapping());
+		}
 
-		Object wrapped = cx.wrap(scope, retval, staticType);
+		Object wrapped = cx.wrap(scope, retval, returnType);
 
-		if (wrapped == null && staticType.isVoid()) {
+		if (wrapped == null && returnType.isVoid()) {
 			wrapped = Undefined.INSTANCE;
 		}
 		return wrapped;

--- a/src/main/java/dev/latvian/mods/rhino/type/ArrayTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/ArrayTypeInfo.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-public final class ArrayTypeInfo extends TypeInfoBase {
+public final class ArrayTypeInfo extends TypeInfoBase.OptionallyConsolidatable {
 	private final TypeInfo component;
 	private Class<?> asClass;
 

--- a/src/main/java/dev/latvian/mods/rhino/type/ArrayTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/ArrayTypeInfo.java
@@ -1,6 +1,9 @@
 package dev.latvian.mods.rhino.type;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 public final class ArrayTypeInfo extends TypeInfoBase {
@@ -60,5 +63,14 @@ public final class ArrayTypeInfo extends TypeInfoBase {
 	@Override
 	public Set<Class<?>> getContainedComponentClasses() {
 		return component.getContainedComponentClasses();
+	}
+
+	@Override
+	protected TypeInfo consolidateImpl(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		var consolidatedComponent = component.consolidate(mapping);
+		if (consolidatedComponent == component) {
+			return this;
+		}
+		return new ArrayTypeInfo(consolidatedComponent);
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/ParameterizedTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/ParameterizedTypeInfo.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public final class ParameterizedTypeInfo extends TypeInfoBase {
+public final class ParameterizedTypeInfo extends TypeInfoBase.OptionallyConsolidatable {
 	private final TypeInfo rawType;
 	private final TypeInfo[] params;
 	private int hashCode;

--- a/src/main/java/dev/latvian/mods/rhino/type/ParameterizedTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/ParameterizedTypeInfo.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.rhino.type;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -116,5 +118,14 @@ public final class ParameterizedTypeInfo extends TypeInfoBase {
 		for (var param : params) {
 			param.collectContainedComponentClasses(classes);
 		}
+	}
+
+	@Override
+	protected TypeInfo consolidateImpl(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		var consolidatedParams = TypeConsolidator.consolidateAll(this.params, mapping);
+		if (consolidatedParams == params) {
+			return this;
+		}
+		return new ParameterizedTypeInfo(this.rawType, consolidatedParams);
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
@@ -6,9 +6,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,6 +69,38 @@ public final class TypeConsolidator {
         }
         return consolidatedAll == null ? original : consolidatedAll;
     }
+
+	@NotNull
+	public static List<@NotNull TypeInfo> consolidateAll(
+		@NotNull List<@NotNull TypeInfo> original,
+		@NotNull Map<VariableTypeInfo, TypeInfo> mapping
+	) {
+		var len = original.size();
+		if (DEBUG) {
+			System.out.println("consolidating" + original);
+		}
+		if (len == 0) {
+			return original;
+		} else if (len == 1) {
+			var consolidated = original.getFirst().consolidate(mapping);
+			return consolidated != original.getFirst() ? List.of(consolidated) : original;
+		}
+		List<@NotNull TypeInfo> consolidatedAll = null;
+		for (int i = 0; i < len; i++) {
+			var type = original.get(i);
+			var consolidated = type.consolidate(mapping);
+			if (consolidated != type) {
+				if (consolidatedAll == null) {
+					consolidatedAll = new ArrayList<>(len);
+					consolidatedAll.addAll(original.subList(0, i));
+				}
+				consolidatedAll.set(i, consolidated);
+			} else if (consolidatedAll != null) {
+				consolidatedAll.set(i, consolidated);
+			}
+		}
+		return consolidatedAll == null ? original : consolidatedAll;
+	}
 
     @Nullable
     private static Map<VariableTypeInfo, TypeInfo> getImpl(Class<?> type) {

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
@@ -138,7 +138,7 @@ public final class TypeConsolidator {
             && parameterized.getRawType() instanceof Class<?> parent
         ) {
             final var params = parent.getTypeParameters(); // T
-            var args = parameterized.getActualTypeArguments(); // T is mapped to
+            final var args = parameterized.getActualTypeArguments(); // T is mapped to
             for (int i = 0; i < args.length; i++) {
                 pushTo.put(TypeInfo.of(params[i]), TypeInfo.of(args[i]));
             }

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.rhino.type;
 
-import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  * @author ZZZank
  */
 public final class TypeConsolidator {
-    private static final Map<Class<?>, Map<VariableTypeInfo, TypeInfo>> MAPPINGS = new Reference2ObjectOpenHashMap<>();
+    private static final Map<Class<?>, Map<VariableTypeInfo, TypeInfo>> MAPPINGS = new IdentityHashMap<>();
 
     private static final boolean DEBUG = false;
 

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
@@ -1,0 +1,168 @@
+package dev.latvian.mods.rhino.type;
+
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * @author ZZZank
+ */
+public final class TypeConsolidator {
+    private static final Map<Class<?>, Map<VariableTypeInfo, TypeInfo>> MAPPINGS = new Reference2ObjectOpenHashMap<>();
+
+    private static final boolean DEBUG = false;
+
+    private TypeConsolidator() {
+    }
+
+    @NotNull
+    public static Map<VariableTypeInfo, TypeInfo> getMapping(Class<?> type) {
+        if (DEBUG) {
+            System.out.println("getting mapping from: " + type);
+        }
+        var got = getImpl(type);
+        return got == null ? Collections.emptyMap() : got;
+    }
+
+    @NotNull
+    public static TypeInfo consolidateOrNone(VariableTypeInfo variable, Map<VariableTypeInfo, TypeInfo> mapping) {
+        return mapping.getOrDefault(variable, TypeInfo.NONE);
+    }
+
+    @NotNull
+    public static TypeInfo[] consolidateAll(
+        @NotNull TypeInfo @NotNull [] original,
+        @NotNull Map<VariableTypeInfo, TypeInfo> mapping
+    ) {
+        var len = original.length;
+        if (DEBUG) {
+            System.out.println("consolidating" + Arrays.toString(original));
+        }
+        if (len == 0) {
+            return original;
+        } else if (len == 1) {
+            var consolidated = original[0].consolidate(mapping);
+            return consolidated != original[0] ? new TypeInfo[]{consolidated} : original;
+        }
+        TypeInfo[] consolidatedAll = null;
+        for (int i = 0; i < len; i++) {
+            var type = original[i];
+            var consolidated = type.consolidate(mapping);
+            if (consolidated != type) {
+                if (consolidatedAll == null) {
+                    consolidatedAll = new TypeInfo[len];
+                    System.arraycopy(original, 0, consolidatedAll, 0, i);
+                }
+                consolidatedAll[i] = consolidated;
+            } else if (consolidatedAll != null) {
+                consolidatedAll[i] = consolidated;
+            }
+        }
+        return consolidatedAll == null ? original : consolidatedAll;
+    }
+
+    @Nullable
+    private static Map<VariableTypeInfo, TypeInfo> getImpl(Class<?> type) {
+        if (type == null || type.isPrimitive() || type == Object.class) {
+            return null;
+        }
+        synchronized (MAPPINGS) {
+            return MAPPINGS.computeIfAbsent(type, TypeConsolidator::collect);
+        }
+    }
+
+    @NotNull
+    private static Map<VariableTypeInfo, TypeInfo> collect(Class<?> type) {
+        var mapping = new IdentityHashMap<VariableTypeInfo, TypeInfo>();
+
+        /**
+         * (classes are named as 'XXX': A, B, C, ...)
+         * (type variables are named as 'Tx': Ta, Tb, Tc, ...)
+		 *
+         * let's consider the most extreme case:
+         * class A<Ta> {}
+         * interface B<Tb> {}
+         * class C<Tc> extends A<Tc> {}
+         * class D<Td> extends C<Td> implements B<A<Td>> {}
+         *
+         * assuming that input 'type' is C.class
+         */
+
+        //collect current level mapping
+        //current level types will only be consolidated by mappings from its subclasses
+        var parent = type.getSuperclass();
+
+        //in our D.class example, this will collect mapping from C<Td>, forming Tc -> Td
+        extractSuperMapping(type.getGenericSuperclass(), mapping);
+
+        //in our D.class example, this will collect mapping from B<A<Td>>, forming Tb -> A<Td>
+        for (var genericInterface : type.getGenericInterfaces()) {
+            extractSuperMapping(genericInterface, mapping);
+        }
+
+        //mapping from super
+        //in our D.class example, super mapping will only include Ta -> Tc
+        var superMapping = getImpl(parent);
+
+        if (superMapping == null || superMapping.isEmpty()) {
+            return postMapping(mapping);
+        }
+
+        //'flatten' super mapping
+        var merged = new IdentityHashMap<>(superMapping);
+        for (var entry : merged.entrySet()) {
+            //in our D.class example, super mapping Ta -> Tc will be 'flattened' to Ta -> Td
+            entry.setValue(entry.getValue().consolidate(mapping));
+        }
+        //merge two mapping
+        merged.putAll(mapping);
+
+        //in our D.class example, our mapping will include Ta -> Td, Tb -> A<Td>, Tc -> Td.
+        //the 'flattened' means that all related type (Ta, Tb, Tc) can be directly mapped to
+        //the type used by D.class (Td), so we only need to apply the mapping ONCE
+        return postMapping(merged);
+    }
+
+    private static void extractSuperMapping(
+        Type superType,
+        IdentityHashMap<VariableTypeInfo, TypeInfo> pushTo
+    ) {
+        if (superType instanceof ParameterizedType parameterized
+            && parameterized.getRawType() instanceof Class<?> parent
+        ) {
+            final var params = parent.getTypeParameters(); // T
+            var args = parameterized.getActualTypeArguments(); // T is mapped to
+            for (int i = 0; i < args.length; i++) {
+                pushTo.put(TypeInfo.of(params[i]), TypeInfo.of(args[i]));
+            }
+        }
+    }
+
+    private static Map<VariableTypeInfo, TypeInfo> postMapping(Map<VariableTypeInfo, TypeInfo> mapping) {
+        switch (mapping.size()) {
+            case 0:
+                if (DEBUG) {
+                    System.out.println("collected empty mapping");
+                }
+                return Collections.emptyMap();
+            case 1:
+                var entry = mapping.entrySet().iterator().next();
+                if (DEBUG) {
+                    System.out.println("collected singleton mapping: " + entry.getKey() + " -> " + entry.getValue());
+                }
+                return Collections.singletonMap(entry.getKey(), entry.getValue());
+            default:
+                if (DEBUG) {
+                    System.out.println("collected mapping with size: " + mapping.size());
+                }
+                return Collections.unmodifiableMap(mapping);
+        }
+    }
+}

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeInfo.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.rhino.type;
 
 import dev.latvian.mods.rhino.Context;
 import dev.latvian.mods.rhino.Scriptable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
@@ -126,6 +127,10 @@ public interface TypeInfo {
 				return BasicClassTypeInfo.CACHE.computeIfAbsent(c, BasicClassTypeInfo::new);
 			}
 		}
+	}
+
+	static VariableTypeInfo of(TypeVariable<?> typeVariable) {
+		return (VariableTypeInfo) VariableTypeInfo.of(typeVariable);
 	}
 
 	static TypeInfo of(Type type) {
@@ -276,5 +281,15 @@ public interface TypeInfo {
 		var set = new LinkedHashSet<Class<?>>();
 		collectContainedComponentClasses(set);
 		return set;
+	}
+
+	/**
+	 * @param mapping see {@link TypeConsolidator#getMapping(Class)}
+	 * @return consolidated type, implementations aare encouraged to return {@code this} if the consolidated type
+	 * is the same as original
+	 */
+	@NotNull
+	default TypeInfo consolidate(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		return this;
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeInfo.java
@@ -130,7 +130,9 @@ public interface TypeInfo {
 	}
 
 	static VariableTypeInfo of(TypeVariable<?> typeVariable) {
-		return (VariableTypeInfo) VariableTypeInfo.of(typeVariable);
+		synchronized (VariableTypeInfo.CACHE) {
+			return VariableTypeInfo.CACHE.computeIfAbsent(typeVariable, VariableTypeInfo::new);
+		}
 	}
 
 	static TypeInfo of(Type type) {
@@ -138,7 +140,7 @@ public interface TypeInfo {
 			case Class<?> clz -> of(clz);
 			case ParameterizedType paramType -> of(paramType.getRawType()).withParams(ofArray(paramType.getActualTypeArguments()));
 			case GenericArrayType arrType -> of(arrType.getGenericComponentType()).asArray();
-			case TypeVariable<?> variable -> VariableTypeInfo.of(variable); // ClassTypeInfo.OBJECT, or NONE?
+			case TypeVariable<?> variable -> of(variable);
 			case WildcardType wildcard -> {
 				var lower = wildcard.getLowerBounds();
 

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeInfoBase.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeInfoBase.java
@@ -8,7 +8,6 @@ import java.util.Map;
 public abstract class TypeInfoBase implements TypeInfo {
 	private TypeInfo asArray;
 	private Object emptyArray;
-	private Boolean consolidatable = null;
 
 	@Override
 	public TypeInfo asArray() {
@@ -32,20 +31,22 @@ public abstract class TypeInfoBase implements TypeInfo {
 		return Array.newInstance(asClass(), length);
 	}
 
-	@Override
-	public @NotNull TypeInfo consolidate(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
-		if (consolidatable == null) {
-			var consolidated = this.consolidateImpl(mapping);
-			consolidatable = consolidated == this;
-			return consolidated;
-		}
-		if (consolidatable) {
-			return this.consolidateImpl(mapping);
-		}
-		return this;
-	}
+	public static abstract class OptionallyConsolidatable extends TypeInfoBase {
+		private Boolean consolidatable = null;
 
-	protected TypeInfo consolidateImpl(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
-		return this;
+		@Override
+		public @NotNull TypeInfo consolidate(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+			if (consolidatable == null) {
+				var consolidated = this.consolidateImpl(mapping);
+				consolidatable = consolidated == this;
+				return consolidated;
+			}
+			if (consolidatable) {
+				return this.consolidateImpl(mapping);
+			}
+			return this;
+		}
+
+		protected abstract TypeInfo consolidateImpl(@NotNull Map<VariableTypeInfo, TypeInfo> mapping);
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/TypeInfoBase.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeInfoBase.java
@@ -1,10 +1,14 @@
 package dev.latvian.mods.rhino.type;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.reflect.Array;
+import java.util.Map;
 
 public abstract class TypeInfoBase implements TypeInfo {
 	private TypeInfo asArray;
 	private Object emptyArray;
+	private Boolean consolidatable = null;
 
 	@Override
 	public TypeInfo asArray() {
@@ -26,5 +30,22 @@ public abstract class TypeInfoBase implements TypeInfo {
 		}
 
 		return Array.newInstance(asClass(), length);
+	}
+
+	@Override
+	public @NotNull TypeInfo consolidate(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		if (consolidatable == null) {
+			var consolidated = this.consolidateImpl(mapping);
+			consolidatable = consolidated == this;
+			return consolidated;
+		}
+		if (consolidatable) {
+			return this.consolidateImpl(mapping);
+		}
+		return this;
+	}
+
+	protected TypeInfo consolidateImpl(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		return this;
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.rhino.type;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.HashMap;
@@ -63,5 +65,10 @@ public class VariableTypeInfo extends TypeInfoBase {
 	@Override
 	public String toString() {
 		return name;
+	}
+
+	@Override
+	public @NotNull TypeInfo consolidate(@NotNull Map<VariableTypeInfo, TypeInfo> mapping) {
+		return mapping.getOrDefault(this, this);
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/VariableTypeInfo.java
@@ -2,69 +2,54 @@ package dev.latvian.mods.rhino.type;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author ZZZank
  * @author Prunoideae
  */
 public class VariableTypeInfo extends TypeInfoBase {
-	private static final Map<TypeVariable<?>, TypeInfo> CACHE = new HashMap<>();
-	private static final Lock READ;
-	private static final Lock WRITE;
+	static final Map<TypeVariable<?>, VariableTypeInfo> CACHE = new HashMap<>();
 
-	static {
-		ReentrantReadWriteLock l = new ReentrantReadWriteLock();
-		READ = l.readLock();
-		WRITE = l.writeLock();
+	private final TypeVariable<?> raw;
+
+	VariableTypeInfo(TypeVariable<?> typeVariable) {
+		this.raw = typeVariable;
 	}
-
-	private TypeInfo consolidated = null;
 
 	/**
-	 * Variable name is needed for type dumping purpose, otherwise I still need
-	 * to create a resolver completely parallel to {@link dev.latvian.mods.rhino.type.TypeInfo#of(Class)}
+	 * ideally this method should never be called because all variable types should be consolidated
+	 * via {@link VariableTypeInfo#consolidate(Map)} before being used.
+	 *
+	 * @see #consolidate(Map)
 	 */
-	private final String name;
-
-	public VariableTypeInfo(String name) {
-		this.name = name;
-	}
-
-	static TypeInfo of(TypeVariable<?> t) {
-		READ.lock();
-		var got = CACHE.get(t);
-		READ.unlock();
-		if (got == null) {
-			WRITE.lock();
-			// a variable type can have multiple bounds, but we only resolves the first one, since type wrapper cannot
-			// magically find or create a class that meets multiple bounds
-			Type bound = t.getBounds()[0];
-			VariableTypeInfo variable = new VariableTypeInfo(t.getName());
-			CACHE.put(t, got = variable);
-			variable.consolidated = TypeInfo.of(bound);
-			WRITE.unlock();
-		}
-		return got;
-	}
-
 	@Override
 	public Class<?> asClass() {
-		return consolidated.asClass();
+		return Object.class;
 	}
 
 	public String getName() {
-		return name;
+		return raw.getName();
+	}
+
+	public TypeInfo[] getBounds() {
+		var rawBounds = raw.getBounds();
+		if (rawBounds.length == 1 && rawBounds[0] == Object.class) {
+			// shortcut for most type variables with no bound
+			return TypeInfo.EMPTY_ARRAY;
+		}
+		return Arrays.stream(rawBounds)
+			.filter(t -> t != Object.class)
+			.map(TypeInfo::of)
+			.toArray(TypeInfo[]::new);
 	}
 
 	@Override
 	public String toString() {
-		return name;
+		return getName();
 	}
 
 	@Override

--- a/src/test/java/dev/latvian/mods/rhino/test/TypeConsolidatorTest.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/TypeConsolidatorTest.java
@@ -2,24 +2,54 @@ package dev.latvian.mods.rhino.test;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author ZZZank
  */
 public class TypeConsolidatorTest {
 	public static final RhinoTest TEST = new RhinoTest("type_consolidator");
 
-	public record Gener<T>(RhinoTest test) {
-		public static final Gener<?> NONE = new Gener<>(TEST);
+	public static final class Gener<T> {
+		public static final Gener<?> NONE = new Gener<>(TEST, List.of());
+		private final RhinoTest test;
+		private final List<T> loaded;
+		/**
+		 * test type consolidation for field
+		 */
+		public T example = null;
+
+		public Gener(RhinoTest test, List<T> loaded) {
+			this.test = test;
+			this.loaded = loaded;
+		}
 
 		/**
 		 * simulate what bindings will usually do, (also there's no other easy way of passing full type info to JS)
 		 */
-		public static Gener<TestConsoleTheme> get() {
-			return new Gener<>(TEST);
+		public static Gener<TestConsoleTheme> of() {
+			return new Gener<>(TEST, new ArrayList<>());
 		}
 
+		/**
+		 * test type consolidation for param
+		 */
 		public void load(T input) {
+			loaded.add(input);
 			test.console.info("type: %s, value: %s".formatted(input.getClass(), input));
+		}
+
+		/**
+		 * test type consolidation for return
+		 */
+		public T get(int index) {
+			return loaded.get(index);
+		}
+
+		@Override
+		public String toString() {
+			return "Gener[test=%s, loaded=%s]".formatted(test, loaded);
 		}
 	}
 
@@ -29,9 +59,18 @@ public class TypeConsolidatorTest {
 
 	@Test
 	void test() {
-		TEST.test("wrap_string", """
-			shared.Gener.get().load("dArk")
+		TEST.test("get_set", """
+			const g = shared.Gener.of();
+			g.load("dArk");
+			console.info(g.get(0));
+			g.example = "light"
+			console.info(g.example);
 			""", """
-			type: %s, value: %s""".formatted(TestConsoleTheme.class, TestConsoleTheme.DARK));
+			type: %s, value: %s
+			%s
+			%s""".formatted(
+			TestConsoleTheme.class, TestConsoleTheme.DARK,
+			TestConsoleTheme.DARK,
+			TestConsoleTheme.LIGHT));
 	}
 }

--- a/src/test/java/dev/latvian/mods/rhino/test/TypeConsolidatorTest.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/TypeConsolidatorTest.java
@@ -1,0 +1,37 @@
+package dev.latvian.mods.rhino.test;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author ZZZank
+ */
+public class TypeConsolidatorTest {
+	public static final RhinoTest TEST = new RhinoTest("type_consolidator");
+
+	public record Gener<T>(RhinoTest test) {
+		public static final Gener<?> NONE = new Gener<>(TEST);
+
+		/**
+		 * simulate what bindings will usually do, (also there's no other easy way of passing full type info to JS)
+		 */
+		public static Gener<TestConsoleTheme> get() {
+			return new Gener<>(TEST);
+		}
+
+		public void load(T input) {
+			test.console.info("type: %s, value: %s".formatted(input.getClass(), input));
+		}
+	}
+
+	static {
+		TEST.shared.put("Gener", Gener.NONE);
+	}
+
+	@Test
+	void test() {
+		TEST.test("wrap_string", """
+			shared.Gener.get().load("dArk")
+			""", """
+			type: %s, value: %s""".formatted(TestConsoleTheme.class, TestConsoleTheme.DARK));
+	}
+}


### PR DESCRIPTION
This PR:
- added TypeConsolidator, providing complete support of Java Generics
- removed "resolve type variable to its bound" feature for VariableTypeInfo, in favor of using TypeConsolidator to eliminate type variables directly
- added `VariableTypeInfo#getBounds()` for ProbeJS, (using `#asClass()` is making ProbeJS unable to handle cases like `T extends A & B & C`)
- added `TypeConsolidatorTest` for testing how it works on method param / method return type / field .

## TypeInfo#consolidate(Map<VariableTypeInfo, TypeInfo>)

The most fundamental method in type consolidating.

Almost all TypeInfo implementation is returning itself or passing the mapping to its components. Only `VariableTypeInfo` will try to map itself to another, consolidated type.

Implementations are carefully tweaked to make simple types always skip type consolidating, and make complex types (`T[]`, `Class<String>`, ...) skip type consolidating if it's proven to be unnecessary.

## Type Consolidation Mapping

aka the `Map<VariableTypeInfo, TypeInfo>` in `TypeInfo#consolidate(...)`. It can be obtained via `TypeConsolidator#getMapping(Class)`, or construct it yourself.

### TypeConsolidator#getMapping(Class)

assuming that we have these classes as a rather extreme case:
```java
// classes are named as 'XXX': A, B, C, ...
// type variables are named as 'Tx': Ta, Tb, Tc, ...
class A<Ta> {}
interface B<Tb> {}
class C<Tc> extends A<Tc> {}
class D<Td> extends C<Td> implements B<A<Td>> {}
```

and we're trying to get mapping for `D.class`, then `TypeConsolidator#getMapping(Class)` will work like this
1. create mapping from super type (C<Td>), forming `Tc -> Td`
2. create mapping from interfaces (B<A<Td>>), forming `Tb -> A<Td>`
3. read mapping for its super class, this will give us `Ta -> Tc`
4. use known mapping to "flatten" super class mapping, this will give us `Ta -> Td` (because `Ta -> Tc` and `Tc -> Td`)
5. merge two mapping together: `Ta -> Td`, `Tb -> A<Td>`, `Tc -> Td`

This mapping can map EVERY type variables used by D's super class/interfaces to types used by D itself, this is important for performance because we only need to apply the mapping once, and no mapping from super classes are required.

## 2-Stage Type Consolidation

assuming that for class D we have these methods:

```java
class D<Td> extends C<Td> implements B<A<Td>> {
    Ta getA() { ... } // inherited from A
    Tb getB() { ... } // inherited from B
    Tc getC() { ... } // inherited from C
    Td getD() { ... }
}
```

### Stage 1

The first type consolidation will happen at type initialization, for example for field:
```diff
		if (type == null) {
-			type = TypeInfo.safeOf(field::getGenericType);
+			type = TypeInfo.safeOf(field::getGenericType)
+				.consolidate(TypeConsolidator.getMapping(this.parent.type));
		}
```

Type consolidation in this stage will remove all usages of type variables from super classes / interfaces.

class D after this stage:
```java
class D<Td> extends C<Td> implements B<A<Td>> {
    Td getA() { ... } // inherited from A
    Td getB() { ... } // inherited from B
    Td getC() { ... } // inherited from C
    Td getD() { ... }
    Td setD(Td td) { ... }
}
```

### Stage 2

This type consolidation will only apply to types with generics. It will be applied to `Function<String, String>`, or `Supplier<SomeEnum>`, but not `ItemStack` or raw type `Map` because there's no generic.

Type consolidation in this stage will map type variables to actual types.

Let's say we already have an instance of D, named `d`, via a method `D<Byte> createD();`.

When trying to invoke `d.setD(...)`, the actual type `Byte` will be used to create another mapping: `Td -> Byte`.

At this time, in Rhino's view, the method `setD` will be:
```java
    Byte setD(Byte td) { ... }
```
You can verify that it's working because other type related features like type wrappers will be functional on generics after this PR.

## Notes

for Pruno:
- using `#asClass()` is making ProbeJS unable to handle cases like `T extends A & B & C`, try `VariableTypeInfo#getBounds()`
- the `getGenericTypeReplacement()` will be redundant if this PR is merged. Try `TypeConsolidator#getMapping(Class)` if you still need something similar
- #53 is basically completely overwritten, hope you don't mind
- hi pruno