### PR TITLE
Allow sizeOfParameters to parse object signatures in arrays.

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/classfile/ClassFileWriter.java
+++ b/src/main/java/dev/latvian/mods/rhino/classfile/ClassFileWriter.java
@@ -278,8 +278,18 @@ public class ClassFileWriter {
 								++count;
 								++index;
 								continue;
-							case 'L':
-								// fall through
+							case 'L': {
+								--stackDiff;
+								++count;
+								++index;
+								int semicolon = pString.indexOf(';', index);
+								if (!(index + 1 <= semicolon && semicolon < rightParenthesis)) {
+									ok = false;
+									break stringLoop;
+								}
+								index = semicolon + 1;
+								continue;
+							}
 							default:
 								ok = false;
 								break stringLoop;


### PR DESCRIPTION
While toying around with Rhino's JavaAdapter class in KubeJS, I tried this piece of code in a startup script:

```java
(() => {
    const KubeJS = Java.loadClass('dev.latvian.mods.kubejs.KubeJS')
    const JavaAdapter = Java.loadClass('dev.latvian.mods.rhino.JavaAdapter')

    const topLevelScope = KubeJS.getStartupScriptManager().contextFactory.enter().topLevelScope
    const sealed = false

    JavaAdapter.init(topLevelScope, sealed)
})()

new JavaAdapter(Java.loadClass('java.awt.Canvas'), {
    paint: function (g) {
        console.log('Hello World!')
    }
})
```

Which threw an `IllegalArgumentException`:

```
...
Exception message: java.lang.IllegalArgumentException: Bad parameter signature: (Ldev/latvian/mods/rhino/Context;Ldev/latvian/mods/rhino/Scriptable;Ldev/latvian/mods/rhino/Function;[Ljava/lang/Object;J)Ljava/lang/Object;
...
```

After a little digging I found this: https://github.com/KubeJS-Mods/Rhino/blob/54379ec9823e4091f091bc9b20ce7d50ffbdbd64/src/main/java/dev/latvian/mods/rhino/JavaAdapter.java#L836-L839

Which then calls the `sizeOfParameters` method: https://github.com/KubeJS-Mods/Rhino/blob/54379ec9823e4091f091bc9b20ce7d50ffbdbd64/src/main/java/dev/latvian/mods/rhino/classfile/ClassFileWriter.java#L2167

Which then reaches the `fall through` section in this block of code: https://github.com/KubeJS-Mods/Rhino/blob/54379ec9823e4091f091bc9b20ce7d50ffbdbd64/src/main/java/dev/latvian/mods/rhino/classfile/ClassFileWriter.java#L261-L286

For some reason, the parsing of object signatures in arrays was ignored and which causes the `IllegalArgumentException`, my PR adds the correct parsing logic so that an exception is not thrown.