### PR TITLE
Refine type consolidation

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
+++ b/src/main/java/dev/latvian/mods/rhino/type/TypeConsolidator.java
@@ -52,21 +52,18 @@ public final class TypeConsolidator {
             var consolidated = original[0].consolidate(mapping);
             return consolidated != original[0] ? new TypeInfo[]{consolidated} : original;
         }
-        TypeInfo[] consolidatedAll = null;
-        for (int i = 0; i < len; i++) {
-            var type = original[i];
-            var consolidated = type.consolidate(mapping);
-            if (consolidated != type) {
-                if (consolidatedAll == null) {
-                    consolidatedAll = new TypeInfo[len];
-                    System.arraycopy(original, 0, consolidatedAll, 0, i);
-                }
-                consolidatedAll[i] = consolidated;
-            } else if (consolidatedAll != null) {
-                consolidatedAll[i] = consolidated;
-            }
-        }
-        return consolidatedAll == null ? original : consolidatedAll;
+		var transformed = original;
+		for (var i = 0; i < original.length; i++) {
+			var type = original[i];
+			var consolidated = type.consolidate(mapping);
+			if (consolidated != type) {
+				if (transformed == original) {
+					transformed = original.clone();
+				}
+				transformed[i] = consolidated;
+			}
+		}
+		return transformed;
     }
 
 	@NotNull
@@ -84,21 +81,18 @@ public final class TypeConsolidator {
 			var consolidated = original.getFirst().consolidate(mapping);
 			return consolidated != original.getFirst() ? List.of(consolidated) : original;
 		}
-		List<@NotNull TypeInfo> consolidatedAll = null;
+		var transformed = original;
 		for (int i = 0; i < len; i++) {
 			var type = original.get(i);
 			var consolidated = type.consolidate(mapping);
 			if (consolidated != type) {
-				if (consolidatedAll == null) {
-					consolidatedAll = new ArrayList<>(len);
-					consolidatedAll.addAll(original.subList(0, i));
+				if (transformed == original) {
+					transformed = new ArrayList<>(original);
 				}
-				consolidatedAll.set(i, consolidated);
-			} else if (consolidatedAll != null) {
-				consolidatedAll.set(i, consolidated);
+				transformed.set(i, consolidated);
 			}
 		}
-		return consolidatedAll == null ? original : consolidatedAll;
+		return transformed;
 	}
 
     @Nullable

--- a/src/test/java/dev/latvian/mods/rhino/test/RhinoTest.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/RhinoTest.java
@@ -1,16 +1,19 @@
 package dev.latvian.mods.rhino.test;
 
 import dev.latvian.mods.rhino.ContextFactory;
+import dev.latvian.mods.rhino.Scriptable;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 public class RhinoTest {
 	public final String testName;
 	public final ContextFactory factory;
 	public TestConsole console;
 	public final Map<String, Object> shared;
+	public BiConsumer<TestContext, Scriptable> scopeAction;
 
 	public RhinoTest(String n) {
 		this.testName = n;
@@ -30,10 +33,13 @@ public class RhinoTest {
 		try {
 			var context = (TestContext) factory.enter();
 			var rootScope = context.initStandardObjects();
+
 			context.addToScope(rootScope, "console", console);
 			context.addToScope(rootScope, "shared", shared);
 			context.addToScope(rootScope, "EventBus", new EventBus(console));
 			context.addToScope(rootScope, "StaticUtils", StaticUtils.class);
+			scopeAction.accept(context, rootScope);
+
 			context.testName = name;
 			context.evaluateString(rootScope, script, testName + "/" + name, 1, null);
 		} catch (Exception ex) {


### PR DESCRIPTION
- TypeConsolidator will now include type mapping from implemented interfaces when collecting type mapping.
- [fix out of bounds in `.consolidateAll(...)`](https://github.com/KubeJS-Mods/Rhino/commit/39349edc2883d1fc1eebf77fc0b88ceca370b51c)
- [implement `VariableTypeInfo.shouldConvert()`](https://github.com/KubeJS-Mods/Rhino/commit/66611481ec58bbdb0fa869be37f982503deba0f8)
- [add test for wildcard type and raw usage of generic class in TypeConsolidatorTest](https://github.com/KubeJS-Mods/Rhino/commit/d6edb20d2cfb61f6f3b486d670d92c9344d2d102)