### PR TITLE
Fix Java Class objects being wrapped as NativeJavaObject

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/Context.java
+++ b/src/main/java/dev/latvian/mods/rhino/Context.java
@@ -1216,6 +1216,8 @@ public class Context {
 			return new NativeJavaList(this, scope, list, list, target);
 		} else if (javaObject instanceof Set<?> set) {
 			return new NativeJavaList(this, scope, set, new JavaSetWrapper<>(set), target);
+		} else if (javaObject instanceof Class<?> clazz) {
+			return new NativeJavaClass(this, scope, clazz);
 		}
 
 		// TODO: Wrap Gson


### PR DESCRIPTION
When Java Class objects get passed from JS to Java they are incorrectly wrapped in NativeJavaObject instead of NativeJavaClass. This PR fixes that.