### PR TITLE
Fix Boolean/Number conversion for unbounded generic type parameters

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/Context.java
+++ b/src/main/java/dev/latvian/mods/rhino/Context.java
@@ -1726,7 +1726,7 @@ public class Context {
 				if (target == TypeInfo.STRING) {
 					// native numbers are #1-8
 					return 9;
-				} else if (target == TypeInfo.OBJECT) {
+				} else if (target.asClass() == Object.class) {
 					return 10;
 				} else if (ScriptRuntime.NumberClass.isAssignableFrom(target.asClass())) {
 					// "double" is #1
@@ -1737,7 +1737,7 @@ public class Context {
 			// "boolean" is #1
 			if (target.isBoolean()) {
 				return CONVERSION_TRIVIAL;
-			} else if (target == TypeInfo.OBJECT) {
+			} else if (target.asClass() == Object.class) {
 				return 3;
 			} else if (target == TypeInfo.STRING) {
 				return 4;


### PR DESCRIPTION
> ## Summary
> JS `boolean` and `number` values fail to dispatch to Java methods with unbounded generic `T` parameters (e.g. `<T> void set(Accessor<T>, T)`), throwing "Can't find method".
>
> The root cause is two identity checks in `Context.getConversionWeight` — the `Boolean` and `Number` branches compare `target == TypeInfo.OBJECT`, which only matches the singleton `BasicClassTypeInfo(Object.class)`. A `VariableTypeInfo` for unbounded `T` has `asClass() == Object.class` but is a different instance, so the check fails. The `switch (fromCode)` below also has no `JSTYPE_BOOLEAN`/`JSTYPE_NUMBER` case, so conversion falls through to `CONVERSION_NONE` and the method becomes invisible to `findFunction`.
>
> ## Fix
> Replace `target == TypeInfo.OBJECT` with `target.asClass() == Object.class` in the `Boolean` and `Number` branches (two lines in `Context.java`).
>
> Strings are unaffected since `CharSequence` branch already uses `target.asClass().isInstance(from)`
>
> ## Reproduction through JS
> ```js
> ItemEvents.rightClicked(event => {
>     let {level, player} = event
>     let entity = player.block.createEntity('camel')
>     entity.entityData.set(entity.DASH, true)
>     entity.spawn()
> })
> ```
> 
> ```
> Can't find method SynchedEntityData.set(EntityDataAccessor, boolean)
> ```