### PR TITLE
Fix issues #39, #42, #43, #65, #67, #69; backport upstream fixes; repair test suite

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/Context.java
+++ b/src/main/java/dev/latvian/mods/rhino/Context.java
@@ -1802,6 +1802,10 @@ public class Context {
 						return 2;
 					}
 					return 12;
+				} else if (target.asClass().isInterface() && from instanceof NativeObject) {
+					// JS objects can implement any interface, including ones with
+					// only default methods (which jsToJava already supported)
+					return 3;
 				} else if (target.isPrimitive() && !target.isBoolean()) {
 					return 4 + getSizeRank(target);
 				}

--- a/src/main/java/dev/latvian/mods/rhino/ES6Generator.java
+++ b/src/main/java/dev/latvian/mods/rhino/ES6Generator.java
@@ -322,6 +322,10 @@ public final class ES6Generator extends IdScriptableObject {
 			if (op == GeneratorState.GENERATOR_THROW) {
 				throw new JavaScriptException(cx, value, lineSource, lineNumber);
 			}
+			if (op == GeneratorState.GENERATOR_CLOSE) {
+				// .return(value) on a completed generator must echo the value back
+				ScriptableObject.putProperty(result, ES6Iterator.VALUE_PROPERTY, value, cx);
+			}
 			ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, Boolean.TRUE, cx);
 			return result;
 		}

--- a/src/main/java/dev/latvian/mods/rhino/IRFactory.java
+++ b/src/main/java/dev/latvian/mods/rhino/IRFactory.java
@@ -1655,12 +1655,9 @@ public final class IRFactory extends Parser {
 			} else if (name.equals("With")) {
 				type = Node.SPECIALCALL_WITH;
 			}
-		} else if (child.getType() == Token.GETPROP) {
-			String name = child.getLastChild().getString();
-			if (name.equals("eval")) {
-				type = Node.SPECIALCALL_EVAL;
-			}
 		}
+		// Note: a property access like a.eval() is NOT a direct eval call and
+		// must not get special treatment (it may be any Java/JS method named eval)
 		Node node = new Node(nodeType, child);
 		if (type != Node.NON_SPECIALCALL) {
 			// Calls to these functions require activation objects.

--- a/src/main/java/dev/latvian/mods/rhino/NativeDate.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeDate.java
@@ -506,7 +506,8 @@ final class NativeDate extends IdScriptableObject {
 				if (Double.isNaN(d) || Double.isInfinite(d)) {
 					return ScriptRuntime.NaN;
 				}
-				array[loop] = ScriptRuntime.toInteger(cx, args[loop]);
+				// don't coerce the raw argument again, its valueOf may have side effects
+				array[loop] = ScriptRuntime.toInteger(d);
 			} else {
 				if (loop == 2) {
 					array[loop] = 1; /* Default the date argument to 1. */

--- a/src/main/java/dev/latvian/mods/rhino/NativeGSON.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeGSON.java
@@ -40,14 +40,33 @@ public class NativeGSON extends NativeJSON {
 			case JsonElement json -> json;
 			case Boolean b -> new JsonPrimitive(b);
 			case CharSequence ignore -> new JsonPrimitive(v.toString());
-			case Number n -> new JsonPrimitive(n);
+			case Number n -> numberPrimitive(n);
 			case NativeString ignore -> new JsonPrimitive(ScriptRuntime.toString(cx, v));
-			case NativeNumber ignore -> new JsonPrimitive(ScriptRuntime.toNumber(cx, v));
+			case NativeNumber ignore -> numberPrimitive(ScriptRuntime.toNumber(cx, v));
+			case NativeObject obj -> {
+				// don't use the Map view here, it can't distinguish undefined (skipped) from null (kept)
+				var json = new JsonObject();
+
+				for (Object id : obj.getIds(cx)) {
+					Object value = id instanceof Integer index ? obj.get(cx, index, obj) : obj.get(cx, String.valueOf(id), obj);
+					if (value == Scriptable.NOT_FOUND || isUnserializable(value)) {
+						continue;
+					} else if (value instanceof Wrapper w) {
+						value = w.unwrap();
+					}
+
+					json.add(String.valueOf(id), stringify0(cx, value));
+				}
+
+				yield json;
+			}
 			case Map<?, ?> map -> {
 				var json = new JsonObject();
 
 				for (var entry : map.entrySet()) {
-					json.add(entry.getKey().toString(), stringify0(cx, entry.getValue()));
+					if (!isUnserializable(entry.getValue())) {
+						json.add(entry.getKey().toString(), stringify0(cx, entry.getValue()));
+					}
 				}
 
 				yield json;
@@ -61,12 +80,24 @@ public class NativeGSON extends NativeJSON {
 
 				yield json;
 			}
+			case Object o when isUnserializable(o) -> JsonNull.INSTANCE;
 			default -> {
 				var json = new JsonArray();
 				cx.getCachedClassStorage(false).get(Wrapper.unwrapped(v).getClass()).getDebugInfo().forEach(json::add);
 				yield json;
 			}
 		};
+	}
+
+	private static JsonElement numberPrimitive(Number n) {
+		double d = n.doubleValue();
+		if (!Double.isFinite(d)) {
+			// JSON has no representation for non-finite numbers
+			return JsonNull.INSTANCE;
+		}
+		long l = (long) d;
+		// integral doubles must not print a ".0" suffix
+		return l == d ? new JsonPrimitive(l) : new JsonPrimitive(n);
 	}
 
 	private final Gson gson;

--- a/src/main/java/dev/latvian/mods/rhino/NativeGlobal.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeGlobal.java
@@ -71,6 +71,7 @@ public class NativeGlobal implements IdFunctionCall {
 		ScriptableObject.defineProperty(scope, "NaN", ScriptRuntime.NaNobj, ScriptableObject.READONLY | ScriptableObject.DONTENUM | ScriptableObject.PERMANENT, cx);
 		ScriptableObject.defineProperty(scope, "Infinity", ScriptRuntime.wrapNumber(Double.POSITIVE_INFINITY), ScriptableObject.READONLY | ScriptableObject.DONTENUM | ScriptableObject.PERMANENT, cx);
 		ScriptableObject.defineProperty(scope, "undefined", Undefined.INSTANCE, ScriptableObject.READONLY | ScriptableObject.DONTENUM | ScriptableObject.PERMANENT, cx);
+		ScriptableObject.defineProperty(scope, "globalThis", scope, ScriptableObject.DONTENUM, cx);
 
         /*
             Each error constructor gets its own Error object as a prototype,

--- a/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJSON.java
@@ -114,7 +114,21 @@ public class NativeJSON extends IdScriptableObject {
 		return builder.toString();
 	}
 
+	/**
+	 * Values that JSON.stringify must not serialize: undefined, functions and symbols.
+	 * They produce undefined at the top level, are skipped in objects and become null in arrays.
+	 */
+	static boolean isUnserializable(Object v) {
+		return Undefined.isUndefined(v) || v instanceof Callable || v instanceof Symbol;
+	}
+
 	// #string_id_map#
+
+	private static void appendNumber(Context cx, StringBuilder builder, Number n) {
+		double d = n.doubleValue();
+		// JSON has no representation for non-finite numbers; integral doubles must not print a ".0" suffix
+		builder.append(Double.isFinite(d) ? ScriptRuntime.toString(cx, n) : "null");
+	}
 
 	private static void escape(StringBuilder builder, String string) {
 		builder.append('"');
@@ -123,19 +137,50 @@ public class NativeJSON extends IdScriptableObject {
 	}
 
 	private static void stringify0(Context cx, Object v, StringBuilder builder) {
-		if (v == null || v instanceof Boolean || v instanceof Number) {
+		if (v == null || v instanceof Boolean) {
 			builder.append(v);
+		} else if (v instanceof Number n) {
+			appendNumber(cx, builder, n);
 		} else if (v instanceof CharSequence) {
 			escape(builder, v.toString());
 		} else if (v instanceof NativeString) {
 			escape(builder, ScriptRuntime.toString(cx, v));
 		} else if (v instanceof NativeNumber) {
-			builder.append(ScriptRuntime.toNumber(cx, v));
+			appendNumber(cx, builder, ScriptRuntime.toNumber(cx, v));
+		} else if (v instanceof NativeObject obj) {
+			// don't use the Map view here, it can't distinguish undefined (skipped) from null (kept)
+			builder.append('{');
+			boolean first = true;
+
+			for (Object id : obj.getIds(cx)) {
+				Object value = id instanceof Integer index ? obj.get(cx, index, obj) : obj.get(cx, String.valueOf(id), obj);
+				if (value == Scriptable.NOT_FOUND || isUnserializable(value)) {
+					continue;
+				} else if (value instanceof Wrapper w) {
+					value = w.unwrap();
+				}
+
+				if (first) {
+					first = false;
+				} else {
+					builder.append(',');
+				}
+
+				escape(builder, String.valueOf(id));
+				builder.append(':');
+				stringify0(cx, value, builder);
+			}
+
+			builder.append('}');
 		} else if (v instanceof Map<?, ?> map) {
 			builder.append('{');
 			boolean first = true;
 
 			for (var entry : map.entrySet()) {
+				if (isUnserializable(entry.getValue())) {
+					continue;
+				}
+
 				if (first) {
 					first = false;
 				} else {
@@ -163,6 +208,8 @@ public class NativeJSON extends IdScriptableObject {
 			}
 
 			builder.append(']');
+		} else if (isUnserializable(v)) {
+			builder.append("null");
 		} else {
 			stringify0(cx, cx.getCachedClassStorage(false).get(Wrapper.unwrapped(v).getClass()).getDebugInfo(), builder);
 		}
@@ -239,6 +286,9 @@ public class NativeJSON extends IdScriptableObject {
 					case 0:
 						/* fall through */
 					default:
+				}
+				if (args.length == 0 || isUnserializable(value)) {
+					return Undefined.INSTANCE;
 				}
 				return stringifyJSON(value, replacer, space, cx);
 			}

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaMap.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaMap.java
@@ -30,9 +30,40 @@ public class NativeJavaMap extends NativeJavaObject {
 		return "JavaMap";
 	}
 
+	/**
+	 * Marker for JS property names that cannot be converted to this map's key type
+	 * and therefore cannot be present in the map.
+	 */
+	private static final Object INVALID_KEY = new Object();
+
+	private Object toMapKey(Context cx, Object jsKey) {
+		try {
+			return cx.jsToJava(jsKey, mapKeyType);
+		} catch (Exception ex) {
+			return INVALID_KEY;
+		}
+	}
+
+	/**
+	 * Checks key presence without propagating exceptions from maps that reject
+	 * keys of an incompatible type (e.g. ClassCastException from a TreeMap with
+	 * non-String comparable keys when a JS property name is looked up).
+	 */
+	private boolean containsKeySafe(Object key) {
+		if (key == INVALID_KEY) {
+			return false;
+		}
+
+		try {
+			return map.containsKey(key);
+		} catch (ClassCastException | NullPointerException ex) {
+			return false;
+		}
+	}
+
 	@Override
 	public boolean has(Context cx, String name, Scriptable start) {
-		if (map.containsKey(name)) {
+		if (containsKeySafe(toMapKey(cx, name))) {
 			return true;
 		}
 		return super.has(cx, name, start);
@@ -40,7 +71,7 @@ public class NativeJavaMap extends NativeJavaObject {
 
 	@Override
 	public boolean has(Context cx, int index, Scriptable start) {
-		if (map.containsKey(index)) {
+		if (containsKeySafe(toMapKey(cx, index))) {
 			return true;
 		}
 		return super.has(cx, index, start);
@@ -48,28 +79,30 @@ public class NativeJavaMap extends NativeJavaObject {
 
 	@Override
 	public Object get(Context cx, String name, Scriptable start) {
-		if (map.containsKey(name)) {
-			return cx.javaToJS(map.get(cx.jsToJava(name, mapKeyType)), start, mapValueType);
+		Object key = toMapKey(cx, name);
+		if (containsKeySafe(key)) {
+			return cx.javaToJS(map.get(key), start, mapValueType);
 		}
 		return super.get(cx, name, start);
 	}
 
 	@Override
 	public Object get(Context cx, int index, Scriptable start) {
-		if (map.containsKey(index)) {
-			return cx.javaToJS(map.get(cx.jsToJava(index, mapKeyType)), start, mapValueType);
+		Object key = toMapKey(cx, index);
+		if (containsKeySafe(key)) {
+			return cx.javaToJS(map.get(key), start, mapValueType);
 		}
 		return super.get(cx, index, start);
 	}
 
 	@Override
 	public void put(Context cx, String name, Scriptable start, Object value) {
-		map.put(name, cx.jsToJava(value, mapValueType));
+		map.put(cx.jsToJava(name, mapKeyType), cx.jsToJava(value, mapValueType));
 	}
 
 	@Override
 	public void put(Context cx, int index, Scriptable start, Object value) {
-		map.put(index, cx.jsToJava(value, mapValueType));
+		map.put(cx.jsToJava(index, mapKeyType), cx.jsToJava(value, mapValueType));
 	}
 
 	@Override
@@ -87,12 +120,18 @@ public class NativeJavaMap extends NativeJavaObject {
 
 	@Override
 	public void delete(Context cx, String name) {
-		Deletable.deleteObject(map.remove(name));
+		Object key = toMapKey(cx, name);
+		if (containsKeySafe(key)) {
+			Deletable.deleteObject(map.remove(key));
+		}
 	}
 
 	@Override
 	public void delete(Context cx, int index) {
-		Deletable.deleteObject(map.remove(index));
+		Object key = toMapKey(cx, index);
+		if (containsKeySafe(key)) {
+			Deletable.deleteObject(map.remove(key));
+		}
 	}
 
 	@Override
@@ -102,6 +141,6 @@ public class NativeJavaMap extends NativeJavaObject {
 	}
 
 	private boolean hasOwnProperty(Context cx, Object[] args) {
-		return map.containsKey(ScriptRuntime.toString(cx, args[0]));
+		return containsKeySafe(toMapKey(cx, ScriptRuntime.toString(cx, args[0])));
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaObject.java
@@ -13,7 +13,6 @@ import dev.latvian.mods.rhino.type.VariableTypeInfo;
 import dev.latvian.mods.rhino.util.DefaultValueTypeHint;
 import dev.latvian.mods.rhino.util.Deletable;
 import dev.latvian.mods.rhino.util.JavaIteratorWrapper;
-import org.openjdk.nashorn.internal.runtime.NativeJavaPackage;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +25,6 @@ import java.util.Map;
  *
  * @author Mike Shaver
  * @see NativeJavaArray
- * @see NativeJavaPackage
  * @see NativeJavaClass
  */
 

--- a/src/main/java/dev/latvian/mods/rhino/NativeMath.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeMath.java
@@ -451,7 +451,7 @@ final class NativeMath extends IdScriptableObject {
 						}
 						return ScriptRuntime.negativeZeroObj;
 					}
-					return 0.5 * Math.log((x + 1.0) / (x - 1.0));
+					return 0.5 * Math.log((1.0 + x) / (1.0 - x));
 				}
 				return ScriptRuntime.NaNobj;
 
@@ -479,7 +479,7 @@ final class NativeMath extends IdScriptableObject {
 				if (n == 0) {
 					return Double32;
 				}
-				return 31 - Math.floor(Math.log(n >>> 0) * LOG2E);
+				return (double) Integer.numberOfLeadingZeros((int) n);
 
 			case Id_cos:
 				x = ScriptRuntime.toNumber(cx, args, 0);
@@ -547,11 +547,11 @@ final class NativeMath extends IdScriptableObject {
 				x = (methodId == Id_max) ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 				for (int i = 0; i != args.length; ++i) {
 					double d = ScriptRuntime.toNumber(cx, args[i]);
-					if (Double.isNaN(d)) {
-						x = d; // NaN
-						break;
-					}
-					if (methodId == Id_max) {
+					// every argument must be coerced (its valueOf may have side
+					// effects), so no early break on NaN
+					if (Double.isNaN(d) || Double.isNaN(x)) {
+						x = Double.NaN;
+					} else if (methodId == Id_max) {
 						// if (x < d) x = d; does not work due to -0.0 >= +0.0
 						x = Math.max(x, d);
 					} else {

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -84,6 +84,11 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 		return ensureScriptable(s, cx);
 	}
 
+	private static Object getValueForId(Context cx, Scriptable obj, Object id) {
+		Object value = id instanceof Integer index ? obj.get(cx, index, obj) : obj.get(cx, ScriptRuntime.toString(cx, id), obj);
+		return value == NOT_FOUND ? Undefined.INSTANCE : value;
+	}
+
 	public final ContextFactory factory;
 
 	public NativeObject(ContextFactory factory) {
@@ -418,7 +423,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				for (int i = 0; i < ids.length; i++) {
 					Object[] entry = new Object[2];
 					entry[0] = ScriptRuntime.toString(cx, ids[i]);
-					entry[1] = obj.get(cx, entry[0].toString(), scope);
+					entry[1] = getValueForId(cx, obj, ids[i]);
 					entries[i] = cx.newArray(scope, entry);
 				}
 				return cx.newArray(scope, entries);
@@ -429,7 +434,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				Object[] ids = obj.getIds(cx);
 				Object[] values = new Object[ids.length];
 				for (int i = 0; i < ids.length; i++) {
-					values[i] = obj.get(cx, ScriptRuntime.toString(cx, ids[i]), scope);
+					values[i] = getValueForId(cx, obj, ids[i]);
 				}
 				return cx.newArray(scope, values);
 			}

--- a/src/main/java/dev/latvian/mods/rhino/NativeString.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeString.java
@@ -856,7 +856,8 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 					if (id == Id_charAt) {
 						return String.valueOf(c);
 					}
-					return c;
+					// charCodeAt must return a Number, not a Character (which would behave like a string)
+					return (int) c;
 				}
 
 				case Id_indexOf: {

--- a/src/main/java/dev/latvian/mods/rhino/NativeSymbol.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeSymbol.java
@@ -88,14 +88,10 @@ public class NativeSymbol extends IdScriptableObject implements Symbol {
 
 	private static NativeSymbol js_constructor(Context cx, Object[] args) {
 		String desc;
-		if (args.length > 0) {
-			if (Undefined.INSTANCE.equals(args[0])) {
-				desc = "";
-			} else {
-				desc = ScriptRuntime.toString(cx, args[0]);
-			}
+		if (args.length > 0 && !Undefined.INSTANCE.equals(args[0])) {
+			desc = ScriptRuntime.toString(cx, args[0]);
 		} else {
-			desc = "";
+			desc = null;
 		}
 
 		if (args.length > 1) {
@@ -263,6 +259,20 @@ public class NativeSymbol extends IdScriptableObject implements Symbol {
 	@Override
 	public String toString() {
 		return key.toString();
+	}
+
+	@Override
+	public Object get(Context cx, String name, Scriptable start) {
+		if (isSymbol() && "description".equals(name)) {
+			String desc = key.getName();
+			return desc == null ? Undefined.INSTANCE : desc;
+		}
+		return super.get(cx, name, start);
+	}
+
+	@Override
+	public boolean has(Context cx, String name, Scriptable start) {
+		return (isSymbol() && "description".equals(name)) || super.has(cx, name, start);
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/rhino/Parser.java
+++ b/src/main/java/dev/latvian/mods/rhino/Parser.java
@@ -1082,7 +1082,9 @@ public class Parser {
 
 			case Token.LET:
 				pn = letStatement();
-				if (pn instanceof VariableDeclaration && peekToken() == Token.SEMI) {
+				if (pn instanceof VariableDeclaration) {
+					// fall through to the semicolon/ASI check below; requiring a
+					// pending semicolon here silently accepted "let a = 4 let b = 5"
 					break;
 				}
 				return pn;

--- a/src/main/java/dev/latvian/mods/rhino/VMBridge.java
+++ b/src/main/java/dev/latvian/mods/rhino/VMBridge.java
@@ -69,11 +69,24 @@ public class VMBridge {
 				}
 			}
 
-			if (method.isDefault()) {
+			if (method.isDefault() && !hasJSImplementation(method)) {
 				return InvocationHandler.invokeDefault(proxy, method, args);
 			} else {
 				return adapter.invoke(cx, target, topScope, proxy, method, args);
 			}
+		}
+
+		/**
+		 * A JS object may override a default method by providing a function
+		 * property of the same name; only fall back to the Java default
+		 * implementation when it doesn't.
+		 */
+		private boolean hasJSImplementation(Method method) {
+			if (target instanceof Callable) {
+				// a lone function only implements the abstract method(s)
+				return false;
+			}
+			return target instanceof Scriptable s && ScriptableObject.getProperty(s, method.getName(), cx) instanceof Callable;
 		}
 	}
 

--- a/src/main/java/dev/latvian/mods/rhino/ast/FunctionNode.java
+++ b/src/main/java/dev/latvian/mods/rhino/ast/FunctionNode.java
@@ -296,6 +296,9 @@ public class FunctionNode extends ScriptNode {
 	public void setIsES6Generator() {
 		isES6Generator = true;
 		isGenerator = true;
+		// Generators need an activation object even if their body contains no
+		// yield, otherwise parameters are silently mis-bound
+		setRequiresActivation();
 	}
 
 	public void addResumptionPoint(Node target) {

--- a/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
+++ b/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
@@ -2597,7 +2597,7 @@ public class NativeRegExp extends IdScriptableObject implements Function {
 
 			case SymbolId_search:
 				Scriptable scriptable = (Scriptable) realThis(thisObj, f, cx).execSub(cx, scope, args, MATCH);
-				return scriptable.get(cx, "index", scriptable);
+				return scriptable == null ? -1 : scriptable.get(cx, "index", scriptable);
 		}
 		throw new IllegalArgumentException(String.valueOf(id));
 	}

--- a/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
@@ -1,0 +1,127 @@
+package dev.latvian.mods.rhino.test;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issues reported on the KubeJS-Mods/Rhino tracker.
+ */
+@SuppressWarnings("unused")
+public class IssueTests {
+	public static final RhinoTest TEST = new RhinoTest("issues");
+
+	@Test
+	public void numberKeyedObjectValues() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/69
+		TEST.test("numberKeyedObjectValues", """
+			const obj = { 0: 50, 1: 25, 2: 18, 3: 7 }
+			console.info(Object.keys(obj).join(','))
+			console.info(Object.values(obj).join(','))
+			console.info(Object.entries(obj).map(e => e.join(':')).join(','))
+			""", """
+			0,1,2,3
+			50,25,18,7
+			0:50,1:25,2:18,3:7
+			""");
+	}
+
+	@Test
+	public void charCodeAt() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/42
+		TEST.test("charCodeAt", """
+			console.info('0'.charCodeAt(0))
+			console.info('0'.charCodeAt(0) + 1)
+			console.info(typeof '0'.charCodeAt(0))
+			console.info(''.charCodeAt(0))
+			""", """
+			48
+			49
+			number
+			NaN
+			""");
+	}
+
+	@Test
+	public void symbolDescription() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/43
+		TEST.test("symbolDescription", """
+			console.info(Symbol('desc').description)
+			console.info(Symbol.iterator.description)
+			console.info(Symbol.for('foo').description)
+			console.info(`${Symbol('foo').description}bar`)
+			console.info(Symbol().description)
+			console.info(Symbol.keyFor(Symbol.for('foo')))
+			""", """
+			desc
+			Symbol.iterator
+			foo
+			foobar
+			undefined
+			foo
+			""");
+	}
+
+	@Test
+	public void jsonStringifyUnserializable() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/39
+		TEST.test("jsonStringifyUnserializable", """
+			console.info(JSON.stringify(undefined))
+			console.info(JSON.stringify(function () {}))
+			console.info(JSON.stringify(Symbol('x')))
+			console.info(JSON.stringify({ a: 1, b: undefined, c: () => 4, d: 'ok' }))
+			console.info(JSON.stringify([1, undefined, () => 4, 2]))
+			""", """
+			undefined
+			undefined
+			undefined
+			{"a":1,"d":"ok"}
+			[1,null,null,2]
+			""");
+	}
+
+	@Test
+	public void jsonStringifyNumbers() {
+		TEST.test("jsonStringifyNumbers", """
+			console.info(JSON.stringify(50))
+			console.info(JSON.stringify(1.5))
+			console.info(JSON.stringify({ a: 1, b: 2.5 }))
+			console.info(JSON.stringify([1, 2, 3]))
+			console.info(JSON.stringify(NaN))
+			console.info(JSON.stringify(Infinity))
+			""", """
+			50
+			1.5
+			{"a":1,"b":2.5}
+			[1,2,3]
+			null
+			null
+			""");
+	}
+
+	@Test
+	public void treeMapWithNonStringKeys() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/67
+		TEST.test("treeMapWithNonStringKeys", """
+			let map = StaticUtils.treeMapWithUuidKeys()
+			map.computeIfAbsent(StaticUtils.uuid('40bd7d77-23f0-4e1c-ae64-4af2d4b0a18d'), k => 'computed')
+			console.info(map.size())
+			console.info(map.get(StaticUtils.uuid('40bd7d77-23f0-4e1c-ae64-4af2d4b0a18d')))
+			""", """
+			2
+			computed
+			""");
+	}
+
+	@Test
+	public void overriddenDefaultMethod() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/65
+		TEST.test("overriddenDefaultMethod", """
+			console.info(StaticUtils.callDefaulted({}))
+			console.info(StaticUtils.callDefaulted({ someMethod: () => 'overridden' }))
+			console.info(StaticUtils.callDefaultedAbstract({ someMethod: () => 'overridden', abstractMethod: () => 'js abstract' }))
+			""", """
+			default
+			overridden
+			overridden,js abstract
+			""");
+	}
+}

--- a/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
@@ -112,6 +112,56 @@ public class IssueTests {
 	}
 
 	@Test
+	public void upstreamBackports() {
+		// assorted small fixes backported from upstream Rhino
+		TEST.test("upstreamBackports", """
+			console.info(Math.atanh(0.5).toFixed(6))
+			console.info(Math.clz32(1))
+			console.info(Math.clz32(2147483648))
+			console.info(globalThis.Math === Math)
+			console.info(/xyz/[Symbol.search]('abc'))
+			console.info((function* (n) { yield n })(42).next().value)
+			let gen = (function* () { yield 1 })()
+			gen.next()
+			gen.next()
+			console.info(gen.return(99).value)
+			let count = 0
+			new Date({ valueOf: () => { count++; return 2020 } }, 0)
+			console.info(count)
+			let obj = { eval: x => x + 1 }
+			console.info(obj.eval(41))
+			""", """
+			0.549306
+			31
+			0
+			true
+			-1
+			42
+			99
+			1
+			42
+			""");
+	}
+
+	@Test
+	public void letRequiresSemicolonOrNewline() {
+		TEST.test("letRequiresSemicolonOrNewline", """
+			try {
+				eval('let a = 4 let b = 5')
+				console.info('accepted')
+			} catch (e) {
+				console.info('rejected')
+			}
+			let c = 1
+			let d = 2
+			console.info(c + d)
+			""", """
+			rejected
+			3
+			""");
+	}
+
+	@Test
 	public void overriddenDefaultMethod() {
 		// https://github.com/KubeJS-Mods/Rhino/issues/65
 		TEST.test("overriddenDefaultMethod", """

--- a/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
@@ -153,7 +153,7 @@ public class MiscTests {
 		TEST.test("jsonStringifyWithNestedArrays", """
 			const thing = {nested: [1, 2, 3]};
 			console.info(JSON.stringify(thing));
-			""", "{\"nested\":[1.0,2.0,3.0]}");
+			""", "{\"nested\":[1,2,3]}");
 	}
 
 	@Test

--- a/src/test/java/dev/latvian/mods/rhino/test/RhinoTest.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/RhinoTest.java
@@ -38,7 +38,10 @@ public class RhinoTest {
 			context.addToScope(rootScope, "shared", shared);
 			context.addToScope(rootScope, "EventBus", new EventBus(console));
 			context.addToScope(rootScope, "StaticUtils", StaticUtils.class);
-			scopeAction.accept(context, rootScope);
+
+			if (scopeAction != null) {
+				scopeAction.accept(context, rootScope);
+			}
 
 			context.testName = name;
 			context.evaluateString(rootScope, script, testName + "/" + name, 1, null);

--- a/src/test/java/dev/latvian/mods/rhino/test/StaticUtils.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/StaticUtils.java
@@ -1,10 +1,45 @@
 package dev.latvian.mods.rhino.test;
 
+import java.util.TreeMap;
+import java.util.UUID;
+
 public class StaticUtils {
 	public static final int immutableInt = 40;
 	public static int mutableInt = 20;
 
 	public static void test(TestConsole console) {
 		console.info("hi");
+	}
+
+	public interface Defaulted {
+		default String someMethod() {
+			return "default";
+		}
+	}
+
+	public interface DefaultedAbstract {
+		String abstractMethod();
+
+		default String someMethod() {
+			return "default";
+		}
+	}
+
+	public static String callDefaulted(Defaulted d) {
+		return d.someMethod();
+	}
+
+	public static String callDefaultedAbstract(DefaultedAbstract d) {
+		return d.someMethod() + "," + d.abstractMethod();
+	}
+
+	public static UUID uuid(String s) {
+		return UUID.fromString(s);
+	}
+
+	public static TreeMap<UUID, String> treeMapWithUuidKeys() {
+		TreeMap<UUID, String> map = new TreeMap<>();
+		map.put(UUID.fromString("d2a4e51b-8c6a-4dbe-b8c2-67a8a9c81e25"), "existing");
+		return map;
 	}
 }


### PR DESCRIPTION
Fixes a batch of open issues, backports small confirmed-live bug fixes from upstream mozilla/rhino, and repairs the test suite. All changes verified with regression tests (67 tests passing).

## Test harness repair

- `RhinoTest.test()` called `scopeAction` unconditionally, but only `TypeConsolidatorTest` ever sets it — **53 of 58 tests had been silently failing with NPE since Aug 2025**. Guarded with a null check.
- Removed an accidental `org.openjdk.nashorn` import in `NativeJavaObject` (only referenced from javadoc, pulls in a nonexistent dependency).

## Issue fixes

- **#69** — `Object.values`/`entries` returned `NOT_FOUND` markers for number-keyed objects (`{ 0: 50 }`). Integer ids from `getIds()` are stored in int-keyed slots and must be looked up with the int overload, not stringified first.
- **#42** — `String.charCodeAt` returned a `Character` (which behaves like a string in JS) instead of a number.
- **#43** — `Symbol.prototype.description` implemented. `Symbol()` with no argument now stores an undefined description (instead of `""`) so `Symbol().description === undefined` per spec; `toString()` output is unchanged.
- **#39** — `JSON.stringify` no longer dumps internal class debug info for `undefined`, functions and symbols: they stringify to `undefined` at top level, are omitted from objects and become `null` in arrays (both `NativeJSON` and `NativeGSON`). Plain JS objects are now serialized via their property ids instead of the `Map` view, which collapses JS `undefined` (must be skipped) into Java `null` (must be kept). Also fixes number output: integral doubles printed a trailing `.0` (not valid JS JSON output) and non-finite numbers now serialize as `null`.
- **#67** — `NativeJavaMap` threw `ClassCastException` when looking up JS property names (e.g. `computeIfAbsent`) on maps with non-String comparable keys such as `TreeMap`. Property names are converted to the map's key type first; lookups that cannot succeed fall through to Java member resolution.
- **#65** — interface adapters unconditionally invoked Java default methods; a JS object providing a function of the same name now overrides them. Also grants conversion weight for JS object → non-functional interface (weight 3, below instance-of matches and functional interfaces) so default-method-only interfaces are usable in overloaded method calls at all — `jsToJava` already supported the conversion, only overload selection rejected it. Registered type wrappers still take precedence (checked first via `internalConversionWeight`, weight `CONVERSION_EXACT`). Note one deliberate re-ranking: a plain JS object passed to a method overloaded on a non-functional interface vs `String` now prefers the interface adapter over stringification.

## Upstream backports (1.7.14 → master era)

- `Math.atanh` used a wrong formula and returned NaN for **every** value in (-1, 1) (upstream `6ec108568`)
- `Math.clz32` log-based rounding errors → `Integer.numberOfLeadingZeros` (upstream `553681af3`)
- `Math.max/min` stopped coercing arguments after the first NaN, skipping observable `valueOf` side effects (upstream `e03bdd143`)
- `globalThis` is now defined (upstream `71c563e73`)
- `RegExp[Symbol.search]` threw NullPointerException when there was no match; returns -1 (upstream `e871ca35a`)
- ES6 generators mis-bound parameters when the body contained no `yield` (no activation was created) (upstream `ec45a62ca`)
- `Generator.return(value)` on a completed generator lost the value (upstream `916e5240b`)
- `Date` constructor coerced each argument twice, calling `valueOf` twice and storing a potentially unvalidated second result (upstream `e6d1e7b1d`)
- ASI did not apply to `let` declarations, so `let a = 4 let b = 5` was silently accepted (upstream `4bf1df910`)
- Property calls named `eval` (`a.eval()`) were treated as direct eval, forcing activation objects and wrong semantics — relevant for any Java API exposing an `eval` method (upstream `edefdbdca`)

The var scoping fix (#35/#36) is split out into its own PR stacked on this one for separate review.

https://claude.ai/code/session_01WP5GTScvdZXwL2x8nwkii4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WP5GTScvdZXwL2x8nwkii4)_