### PR TITLE
Fix var scoping (#35, #36): restore function-scoped var hoisting

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/NodeTransformer.java
+++ b/src/main/java/dev/latvian/mods/rhino/NodeTransformer.java
@@ -429,6 +429,7 @@ public class NodeTransformer {
 			result = replaceCurrent(parent, previous, scopeNode, result);
 			ArrayList<Object> list = new ArrayList<>();
 			Node objectLiteral = new Node(Token.OBJECTLIT);
+			Node assignments = new Node(Token.BLOCK);
 			for (Node v = vars.getFirstChild(); v != null; v = v.getNext()) {
 				Node current = v;
 				if (current.getType() == Token.LETEXPR) {
@@ -459,10 +460,22 @@ public class NodeTransformer {
 				}
 				list.add(ScriptRuntime.getIndexObject(current.getString()));
 				Node init = current.getFirstChild();
+				if (init != null && !isExpression) {
+					// ES6 semantics: run initializers sequentially inside the new
+					// scope so that later ones can reference earlier variables,
+					// e.g. for (let a = 1, b = a; ...)
+					current.removeChild(init);
+					Node bind = Node.newString(Token.BINDNAME, current.getString());
+					assignments.addChildToBack(new Node(Token.EXPR_VOID, new Node(Token.SETNAME, bind, init)));
+					init = null;
+				}
 				if (init == null) {
 					init = new Node(Token.VOID, Node.newNumber(0.0));
 				}
 				objectLiteral.addChildToBack(init);
+			}
+			if (assignments.hasChildren()) {
+				body = new Node(Token.BLOCK, assignments, body);
 			}
 			objectLiteral.putProp(Node.OBJECT_IDS_PROP, list.toArray());
 			newVars = new Node(Token.ENTERWITH, objectLiteral);

--- a/src/main/java/dev/latvian/mods/rhino/Parser.java
+++ b/src/main/java/dev/latvian/mods/rhino/Parser.java
@@ -1482,7 +1482,7 @@ public class Parser {
 				init.setLineno(ts.lineno);
 			} else if (tt == Token.VAR || tt == Token.LET || tt == Token.CONST) {
 				consumeToken();
-				init = variables(Token.LET, ts.tokenBeg, false);
+				init = variables(tt, ts.tokenBeg, false);
 			} else {
 				init = expr();
 
@@ -2095,71 +2095,70 @@ public class Parser {
 	}
 
 	void defineSymbol(int declType, String name, boolean ignoreNotInBlock) {
-		// help me :(
-
 		if (name == null) {
 			codeBug();
 		}
 
 		Scope definingScope = currentScope.getDefiningScope(name);
 		AstSymbol symbol = definingScope != null ? definingScope.getSymbol(name) : null;
-
-		if (symbol != null && definingScope == currentScope) {
-			addError(switch (symbol.getDeclType()) {
-				case Token.LET -> "msg.let.redecl";
-				case Token.VAR -> "msg.var.redecl";
-				case Token.CONST -> "msg.const.redecl";
-				case Token.FUNCTION -> "msg.fn.redecl";
-				default -> "msg.parm.redecl";
-			}, name);
-
-			return;
-		}
-
-		/*
 		int symDeclType = symbol != null ? symbol.getDeclType() : -1;
-		if (symbol != null && (symDeclType == Token.CONST || declType == Token.CONST || (definingScope == currentScope && symDeclType == Token.LET))) {
-			addError(symDeclType == Token.CONST ? "msg.const.redecl" : symDeclType == Token.LET ? "msg.let.redecl" : symDeclType == Token.VAR ? "msg.var.redecl" : symDeclType == Token.FUNCTION ? "msg.fn.redecl" : "msg.parm.redecl", name);
-			return;
-		}
-		 */
 
 		switch (declType) {
-			case Token.LET, Token.VAR, Token.CONST, Token.FUNCTION, Token.LP -> currentScope.putSymbol(new AstSymbol(declType, name));
-			default -> throw Kit.codeBug();
-		}
-
-		/*
-		switch (declType) {
-			case Token.LET -> {
-				if (!ignoreNotInBlock && ((currentScope.getType() == Token.IF) || currentScope instanceof Loop)) {
-					addError("msg.let.decl.not.in.block");
+			case Token.LET, Token.CONST -> {
+				// block scoped; redeclaring any binding in the same scope is an error
+				if (symbol != null && definingScope == currentScope) {
+					addError(switch (symDeclType) {
+						case Token.LET -> "msg.let.redecl";
+						case Token.VAR -> "msg.var.redecl";
+						case Token.CONST -> "msg.const.redecl";
+						case Token.FUNCTION -> "msg.fn.redecl";
+						default -> "msg.parm.redecl";
+					}, name);
 					return;
 				}
-				currentScope.putSymbol(new Symbol(declType, name));
+				currentScope.putSymbol(new AstSymbol(declType, name));
 			}
-			case Token.VAR, Token.CONST, Token.FUNCTION -> {
-				if (symbol != null) {
-					if (symDeclType == Token.VAR) {
-						addStrictWarning("msg.var.redecl", name);
-					} else if (symDeclType == Token.LP) {
-						addStrictWarning("msg.var.hides.arg", name);
-					}
-				} else {
-					currentScriptOrFn.putSymbol(new Symbol(declType, name));
+			case Token.VAR, Token.FUNCTION -> {
+				// function scoped: hoisted to the enclosing function or script.
+				// Conflicts with a lexical binding declared anywhere between here
+				// and the function top are errors; duplicate vars are allowed.
+				if (symbol != null && (symDeclType == Token.LET || symDeclType == Token.CONST) && scopeIsWithinCurrentFunction(definingScope)) {
+					addError(symDeclType == Token.CONST ? "msg.const.redecl" : "msg.let.redecl", name);
+					return;
+				}
+				if (symbol == null || definingScope != currentScriptOrFn) {
+					currentScriptOrFn.putSymbol(new AstSymbol(declType, name));
 				}
 			}
 			case Token.LP -> {
-				if (symbol != null) {
-					// must be duplicate parameter. Second parameter hides the
+				if (symbol != null && definingScope == currentScriptOrFn) {
+					// must be a duplicate parameter. Second parameter hides the
 					// first, so go ahead and add the second parameter
 					addWarning("msg.dup.parms", name);
 				}
-				currentScriptOrFn.putSymbol(new Symbol(declType, name));
+				currentScriptOrFn.putSymbol(new AstSymbol(declType, name));
 			}
 			default -> throw codeBug();
 		}
-		 */
+	}
+
+	/**
+	 * Returns whether the given scope is between the current scope and the
+	 * enclosing function (or script) top, i.e. a hoisted var declared here
+	 * would collide with bindings declared in it.
+	 */
+	private boolean scopeIsWithinCurrentFunction(Scope scope) {
+		Scope s = currentScope;
+		while (s != null) {
+			if (s == scope) {
+				return true;
+			}
+			if (s == currentScriptOrFn) {
+				return false;
+			}
+			s = s.getParentScope();
+		}
+		return false;
 	}
 
 	private AstNode expr() throws IOException {

--- a/src/main/java/dev/latvian/mods/rhino/ast/Scope.java
+++ b/src/main/java/dev/latvian/mods/rhino/ast/Scope.java
@@ -33,7 +33,7 @@ public class Scope extends Jump {
 		scope.symbolTable = null;
 		result.parent = scope.parent;
 		result.setParentScope(scope.getParentScope());
-		result.setParentScope(result);
+		scope.setParentScope(result);
 		scope.parent = result;
 		result.top = scope.top;
 		return result;

--- a/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/IssueTests.java
@@ -98,6 +98,60 @@ public class IssueTests {
 	}
 
 	@Test
+	public void varFunctionScoping() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/36
+		TEST.test("varFunctionScoping", """
+			if (1) { var thing = 'exists!' }
+			console.info(thing)
+			function f() {
+				if (true) { var inner = 'inner!' }
+				return inner
+			}
+			console.info(f())
+			""", """
+			exists!
+			inner!
+			""");
+	}
+
+	@Test
+	public void varInForLoopInit() {
+		// https://github.com/KubeJS-Mods/Rhino/issues/35
+		TEST.test("varInForLoopInit", """
+			let out = []
+			for (var x = 0, y = x; y < 3; y++) { out.push(y) }
+			console.info(out.join(','))
+			for (var g = 0; g < 2; g++) {}
+			console.info(g)
+			""", """
+			0,1,2
+			2
+			""");
+	}
+
+	@Test
+	public void letInForLoopInitReferencingEarlierVar() {
+		TEST.test("letInForLoopInitReferencingEarlierVar", """
+			let out = []
+			for (let a = 1, b = a; b < 4; b++) { out.push(a + ':' + b) }
+			console.info(out.join(','))
+			console.info(typeof a)
+			""", """
+			1:1,1:2,1:3
+			undefined
+			""");
+	}
+
+	@Test
+	public void duplicateVarAllowed() {
+		TEST.test("duplicateVarAllowed", """
+			var d = 1
+			var d = 2
+			console.info(d)
+			""", "2");
+	}
+
+	@Test
 	public void treeMapWithNonStringKeys() {
 		// https://github.com/KubeJS-Mods/Rhino/issues/67
 		TEST.test("treeMapWithNonStringKeys", """


### PR DESCRIPTION
**Stacked on #74** — review/merge that one first; this PR's diff is the single var-scoping commit on top of it. Once #74 is merged (and its branch deleted), GitHub will retarget this PR to `main`.

Fixes #35 and #36: `var` is function-scoped again, restoring standard JS semantics that TypeScript/Babel-transpiled output depends on. Four distinct root causes, each visible in the diff:

1. **`Parser.defineSymbol`** put every declaration — including `var` and `function` — into the innermost block scope, making `var` effectively block-scoped (`if (1) { var thing = 1 } thing` → ReferenceError). `var`/`function` declarations now hoist to the enclosing function or script scope as upstream does, while `let`/`const` keep this fork's ES6 block scoping. Duplicate `var` declarations are allowed again (common in transpiled output); a `var` colliding with a lexical binding declared in an enclosing block of the same function is a syntax error.

2. **`Parser.forLoopInit`** force-rewrote `var` (and `const`) to `let` in for-loop initializers, so `for (var i = 0; ...) ...; use(i)` never escaped the loop. The declaration type is now preserved.

3. **`Scope.splitScope`** contained a typo'd line (`result.setParentScope(result)` — making the split-off scope its own parent) that left the moved symbol table unreachable from the loop scope. This is why any for-loop init whose later variable referenced an earlier one (`for (let a = 1, b = a; ...)`) threw `ReferenceError`.

4. **`NodeTransformer.visitLet`** evaluated all `let` initializers inside an object literal *before* entering the scope (old JS 1.7 `let (a=b)` expression semantics). Statement-form `let` initializers now run sequentially inside the new scope per ES6, so later initializers can reference earlier variables. Let-*expression* lowering (used by internal destructuring desugarings) keeps the old behavior.

Known remaining limitation (pre-existing, also long-standing in upstream of this era, not addressed here): `let` in for-loops does not get per-iteration bindings, so closures created in the loop body observe the final value.

All 71 tests pass, including new regression tests for var hoisting out of blocks, `var`/`let` multi-variable for-initializers with cross-references, `var` escaping for-loops, and duplicate `var` declarations.

https://claude.ai/code/session_01WP5GTScvdZXwL2x8nwkii4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WP5GTScvdZXwL2x8nwkii4)_