### PR TITLE
Assorted backports from upstream

### DIFF
--- a/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
@@ -1,0 +1,103 @@
+package dev.latvian.mods.rhino;
+
+/**
+ * Abstract Object Operations as defined by EcmaScript
+ *
+ * @see <a href="https://262.ecma-international.org/11.0/#sec-operations-on-objects">Abstract Operations - Operations on Objects</a>
+ */
+class AbstractEcmaObjectOperations {
+	enum INTEGRITY_LEVEL {
+		FROZEN,
+		SEALED
+	}
+
+	/**
+	 * Implementation of Abstract Object operation testIntegrityLevel as defined by EcmaScript
+	 *
+	 * @see <a href="https://262.ecma-international.org/11.0/#sec-testintegritylevel">TestIntegrityLevel</a>
+	 */
+	static boolean testIntegrityLevel(Context cx, Object o, INTEGRITY_LEVEL level) {
+		ScriptableObject obj = ScriptableObject.ensureScriptableObject(o, cx);
+
+		if (obj.isExtensible()) {
+			return Boolean.FALSE;
+		}
+
+		for (Object name : obj.getIds(cx, true, true)) {
+			ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
+			if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
+				return Boolean.FALSE;
+			}
+
+			if (level == INTEGRITY_LEVEL.FROZEN && obj.isDataDescriptor(desc, cx) && Boolean.TRUE.equals(desc.get(cx, "writable"))) {
+				return Boolean.FALSE;
+			}
+		}
+
+		return Boolean.TRUE;
+	}
+
+	/**
+	 * Implementation of Abstract Object operation setIntegrityLevel as defined by EcmaScript
+	 * <p>
+	 * Implementation currently tightly coupled with ScriptableObject impl.
+	 * which allow some optimization.
+	 *
+	 * @see <a href="https://262.ecma-international.org/11.0/#sec-setintegritylevel">SetIntegrityLevel</a>
+	 */
+	static boolean setIntegrityLevel(Context cx, Object o, INTEGRITY_LEVEL level) {
+		/*
+			1. Assert: Type(O) is Object.
+			2. Assert: level is either sealed or frozen.
+			3. Let status be ? O.[[PreventExtensions]]().
+			4. If status is false, return false.
+			5. Let keys be ? O.[[OwnPropertyKeys]]().
+			6. If level is sealed, then
+				a. For each element k of keys, do
+					i. Perform ? DefinePropertyOrThrow(O, k, PropertyDescriptor { [[Configurable]]: false }).
+			7. Else,
+				a. Assert: level is frozen.
+				b. For each element k of keys, do
+					i. Let currentDesc be ? O.[[GetOwnProperty]](k).
+					ii. If currentDesc is not undefined, then
+						1. If IsAccessorDescriptor(currentDesc) is true, then
+							a. Let desc be the PropertyDescriptor { [[Configurable]]: false }.
+						2. Else,
+							a. Let desc be the PropertyDescriptor { [[Configurable]]: false, [[Writable]]: false }.
+						3. Perform ? DefinePropertyOrThrow(O, k, desc).
+			8. Return true.
+
+			NOTES
+			- Step 3 calls for the .preventExtensions() before updating the propertyDescriptors,
+			  In Rhino however .preventExtensions() never returns false
+			  and calling it before will block updating the propertyDescriptors afterwards
+			- While steps 6.a.i and 7.b.ii.3 call for the Abstract DefinePropertyOrThrow operation,
+			  the conditions under which a throw would occur aren't applicable when freezing or sealing an object
+		 */
+		ScriptableObject obj = ScriptableObject.ensureScriptableObject(o, cx);
+
+		for (Object key : obj.getIds(cx, true, true)) {
+			ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, key);
+
+			if (level == INTEGRITY_LEVEL.SEALED) {
+				if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
+					desc.put(cx, "configurable", desc, Boolean.FALSE);
+
+					obj.defineOwnProperty(cx, key, desc, false);
+				}
+			} else {
+				if (obj.isDataDescriptor(desc, cx) && Boolean.TRUE.equals(desc.get(cx, "writable"))) {
+					desc.put(cx, "writable", desc, Boolean.FALSE);
+				}
+				if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
+					desc.put(cx, "configurable", desc, Boolean.FALSE);
+				}
+				obj.defineOwnProperty(cx, key, desc, false);
+			}
+		}
+
+		obj.preventExtensions();
+
+		return true;
+	}
+}

--- a/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
@@ -1,5 +1,10 @@
 package dev.latvian.mods.rhino;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Abstract Object Operations as defined by EcmaScript
  *
@@ -121,5 +126,55 @@ class AbstractEcmaObjectOperations {
 		obj.preventExtensions();
 
 		return true;
+	}
+
+	enum KEY_COERCION {
+		PROPERTY,
+		COLLECTION,
+	}
+
+	/**
+	 * Implement the ECMAScript abstract operation "GroupBy" defined in section 7.3.35 of ECMA262.
+	 *
+	 * @see <a href="https://tc39.es/ecma262/#sec-groupby"></a>
+	 */
+	static Map<Object, List<Object>> groupBy(Context cx, Scriptable scope, IdFunctionObject f, Object items, Object callback, KEY_COERCION keyCoercion) {
+		ScriptRuntimeES6.requireObjectCoercible(cx, items, f);
+		if (!(callback instanceof Callable)) {
+			throw ScriptRuntime.notFunctionError(cx, callback);
+		}
+
+		// LinkedHashMap used to preserve key creation order
+		Map<Object, List<Object>> groups = new LinkedHashMap<>();
+		final Object iterator = ScriptRuntime.callIterator(cx, scope, items);
+		try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
+			double i = 0;
+			for (Object o : it) {
+				if (i > NativeNumber.MAX_SAFE_INTEGER) {
+					it.close();
+					throw ScriptRuntime.typeError(cx, "Too many values to iterate");
+				}
+
+				Object[] args = {o, i};
+				Object key = ((Callable) callback).call(cx, scope, Undefined.SCRIPTABLE_INSTANCE, args);
+				if (keyCoercion == KEY_COERCION.PROPERTY) {
+					if (!ScriptRuntime.isSymbol(key)) {
+						key = ScriptRuntime.toString(cx, key);
+					}
+				} else {
+					assert keyCoercion == KEY_COERCION.COLLECTION;
+					if ((key instanceof Number) && ((Number) key).doubleValue() == ScriptRuntime.negativeZero) {
+						key = ScriptRuntime.zeroObj;
+					}
+				}
+
+				List<Object> group = groups.computeIfAbsent(key, (k) -> new ArrayList<>());
+				group.add(o);
+
+				i++;
+			}
+		}
+
+		return groups;
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
@@ -12,6 +12,28 @@ class AbstractEcmaObjectOperations {
 	}
 
 	/**
+	 * Implementation of Abstract Object operation HasOwnProperty as defined by EcmaScript
+	 *
+	 * @see <a href="https://262.ecma-international.org/12.0/#sec-hasownproperty">HasOwnProperty</a>
+	 */
+	static boolean hasOwnProperty(Context cx, Object o, Object property) {
+		ScriptableObject obj = ScriptableObject.ensureScriptableObject(o, cx);
+		boolean result;
+		if (property instanceof Symbol sym) {
+			result = ScriptableObject.ensureSymbolScriptable(o, cx).has(cx, sym, obj);
+		} else {
+			ScriptRuntime.StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, property);
+			if (s.stringId == null) {
+				result = obj.has(cx, s.index, obj);
+			} else {
+				result = obj.has(cx, s.stringId, obj);
+			}
+		}
+
+		return result;
+	}
+
+	/**
 	 * Implementation of Abstract Object operation testIntegrityLevel as defined by EcmaScript
 	 *
 	 * @see <a href="https://262.ecma-international.org/11.0/#sec-testintegritylevel">TestIntegrityLevel</a>

--- a/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/AbstractEcmaObjectOperations.java
@@ -17,7 +17,7 @@ class AbstractEcmaObjectOperations {
 	 * @see <a href="https://262.ecma-international.org/12.0/#sec-hasownproperty">HasOwnProperty</a>
 	 */
 	static boolean hasOwnProperty(Context cx, Object o, Object property) {
-		ScriptableObject obj = ScriptableObject.ensureScriptableObject(o, cx);
+		Scriptable obj = ScriptableObject.ensureScriptable(o, cx);
 		boolean result;
 		if (property instanceof Symbol sym) {
 			result = ScriptableObject.ensureSymbolScriptable(o, cx).has(cx, sym, obj);

--- a/src/main/java/dev/latvian/mods/rhino/ArrayLikeAbstractOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/ArrayLikeAbstractOperations.java
@@ -17,6 +17,8 @@ public class ArrayLikeAbstractOperations {
 		SOME,
 		FIND,
 		FIND_INDEX,
+		FIND_LAST,
+		FIND_LAST_INDEX,
 	}
 
 	public enum ReduceOperation {
@@ -30,7 +32,7 @@ public class ArrayLikeAbstractOperations {
 	public static Object iterativeMethod(Context cx, IdFunctionObject fun, IterativeOperation operation, Scriptable scope, Scriptable thisObj, Object[] args) {
 		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
-		if (IterativeOperation.FIND == operation || IterativeOperation.FIND_INDEX == operation) {
+		if (IterativeOperation.FIND == operation || IterativeOperation.FIND_INDEX == operation || IterativeOperation.FIND_LAST == operation || IterativeOperation.FIND_LAST_INDEX == operation) {
 			ScriptRuntimeES6.requireObjectCoercible(cx, o, fun);
 		}
 
@@ -52,11 +54,15 @@ public class ArrayLikeAbstractOperations {
 			array = cx.newArray(scope, resultLength);
 		}
 		long j = 0;
-		for (long i = 0; i < length; i++) {
+		boolean reverse = operation == IterativeOperation.FIND_LAST || operation == IterativeOperation.FIND_LAST_INDEX;
+		long start = reverse ? length - 1 : 0;
+		long end = reverse ? -1 : length;
+		long increment = reverse ? -1 : +1;
+		for (long i = start; i != end; i += increment) {
 			Object[] innerArgs = new Object[3];
 			Object elem = getRawElem(o, i, cx);
 			if (elem == Scriptable.NOT_FOUND) {
-				if (operation == IterativeOperation.FIND || operation == IterativeOperation.FIND_INDEX) {
+				if (operation == IterativeOperation.FIND || operation == IterativeOperation.FIND_INDEX || operation == IterativeOperation.FIND_LAST || operation == IterativeOperation.FIND_LAST_INDEX) {
 					elem = Undefined.INSTANCE;
 				} else {
 					continue;
@@ -88,11 +94,13 @@ public class ArrayLikeAbstractOperations {
 					}
 					break;
 				case FIND:
+				case FIND_LAST:
 					if (ScriptRuntime.toBoolean(cx, result)) {
 						return elem;
 					}
 					break;
 				case FIND_INDEX:
+				case FIND_LAST_INDEX:
 					if (ScriptRuntime.toBoolean(cx, result)) {
 						return ScriptRuntime.wrapNumber(i);
 					}
@@ -103,7 +111,7 @@ public class ArrayLikeAbstractOperations {
 			case EVERY -> Boolean.TRUE;
 			case FILTER, MAP -> array;
 			case SOME -> Boolean.FALSE;
-			case FIND_INDEX -> ScriptRuntime.wrapNumber(-1);
+			case FIND_INDEX, FIND_LAST_INDEX -> ScriptRuntime.wrapNumber(-1);
 			default -> Undefined.INSTANCE;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/ArrayLikeAbstractOperations.java
+++ b/src/main/java/dev/latvian/mods/rhino/ArrayLikeAbstractOperations.java
@@ -1,0 +1,261 @@
+package dev.latvian.mods.rhino;
+
+import dev.latvian.mods.rhino.regexp.NativeRegExp;
+
+import java.util.Comparator;
+
+/**
+ * Abstract Operations for Array-like objects as defined by EcmaScript,
+ * shared by NativeArray and (in upstream Rhino) the TypedArray views.
+ */
+public class ArrayLikeAbstractOperations {
+	public enum IterativeOperation {
+		EVERY,
+		FILTER,
+		FOR_EACH,
+		MAP,
+		SOME,
+		FIND,
+		FIND_INDEX,
+	}
+
+	public enum ReduceOperation {
+		REDUCE,
+		REDUCE_RIGHT,
+	}
+
+	/**
+	 * Implements the methods "every", "filter", "forEach", "map", and "some".
+	 */
+	public static Object iterativeMethod(Context cx, IdFunctionObject fun, IterativeOperation operation, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+
+		if (IterativeOperation.FIND == operation || IterativeOperation.FIND_INDEX == operation) {
+			ScriptRuntimeES6.requireObjectCoercible(cx, o, fun);
+		}
+
+		long length = NativeArray.getLengthProperty(cx, o, operation == IterativeOperation.MAP);
+		Object callbackArg = args.length > 0 ? args[0] : Undefined.INSTANCE;
+
+		Function f = getCallbackArg(cx, callbackArg);
+		Scriptable parent = ScriptableObject.getTopLevelScope(f);
+		Scriptable thisArg;
+		if (args.length < 2 || args[1] == null || args[1] == Undefined.INSTANCE) {
+			thisArg = parent;
+		} else {
+			thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
+		}
+
+		Scriptable array = null;
+		if (operation == IterativeOperation.FILTER || operation == IterativeOperation.MAP) {
+			int resultLength = operation == IterativeOperation.MAP ? (int) length : 0;
+			array = cx.newArray(scope, resultLength);
+		}
+		long j = 0;
+		for (long i = 0; i < length; i++) {
+			Object[] innerArgs = new Object[3];
+			Object elem = getRawElem(o, i, cx);
+			if (elem == Scriptable.NOT_FOUND) {
+				if (operation == IterativeOperation.FIND || operation == IterativeOperation.FIND_INDEX) {
+					elem = Undefined.INSTANCE;
+				} else {
+					continue;
+				}
+			}
+			innerArgs[0] = elem;
+			innerArgs[1] = i;
+			innerArgs[2] = o;
+			Object result = f.call(cx, parent, thisArg, innerArgs);
+			switch (operation) {
+				case EVERY:
+					if (!ScriptRuntime.toBoolean(cx, result)) {
+						return Boolean.FALSE;
+					}
+					break;
+				case FILTER:
+					if (ScriptRuntime.toBoolean(cx, result)) {
+						defineElem(cx, array, j++, innerArgs[0]);
+					}
+					break;
+				case FOR_EACH:
+					break;
+				case MAP:
+					defineElem(cx, array, i, result);
+					break;
+				case SOME:
+					if (ScriptRuntime.toBoolean(cx, result)) {
+						return Boolean.TRUE;
+					}
+					break;
+				case FIND:
+					if (ScriptRuntime.toBoolean(cx, result)) {
+						return elem;
+					}
+					break;
+				case FIND_INDEX:
+					if (ScriptRuntime.toBoolean(cx, result)) {
+						return ScriptRuntime.wrapNumber(i);
+					}
+					break;
+			}
+		}
+		return switch (operation) {
+			case EVERY -> Boolean.TRUE;
+			case FILTER, MAP -> array;
+			case SOME -> Boolean.FALSE;
+			case FIND_INDEX -> ScriptRuntime.wrapNumber(-1);
+			default -> Undefined.INSTANCE;
+		};
+	}
+
+	static Function getCallbackArg(Context cx, Object callbackArg) {
+		if (!(callbackArg instanceof Function f)) {
+			throw ScriptRuntime.notFunctionError(cx, callbackArg);
+		}
+		if (callbackArg instanceof NativeRegExp) {
+			// Previously, it was allowed to pass RegExp instance as a callback (it implements Function)
+			// But according to ES2015 21.2.6 Properties of RegExp Instances:
+			// > RegExp instances are ordinary objects that inherit properties from the RegExp prototype object.
+			// > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]].
+			// so, no [[Call]] for RegExp-s
+			throw ScriptRuntime.notFunctionError(cx, callbackArg);
+		}
+
+		return f;
+	}
+
+	static void defineElem(Context cx, Scriptable target, long index, Object value) {
+		if (index > Integer.MAX_VALUE) {
+			String id = Long.toString(index);
+			target.put(cx, id, target, value);
+		} else {
+			target.put(cx, (int) index, target, value);
+		}
+	}
+
+	// same as NativeArray::getElem, but without converting NOT_FOUND to undefined
+	static Object getRawElem(Scriptable target, long index, Context cx) {
+		if (index > Integer.MAX_VALUE) {
+			return ScriptableObject.getProperty(target, Long.toString(index), cx);
+		}
+		return ScriptableObject.getProperty(target, (int) index, cx);
+	}
+
+	public static long toSliceIndex(double value, long length) {
+		long result;
+		if (value < 0.0) {
+			if (value + length < 0.0) {
+				result = 0;
+			} else {
+				result = (long) (value + length);
+			}
+		} else if (value > length) {
+			result = length;
+		} else {
+			result = (long) value;
+		}
+		return result;
+	}
+
+	/**
+	 * Implements the methods "reduce" and "reduceRight".
+	 */
+	public static Object reduceMethod(Context cx, ReduceOperation operation, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+
+		long length = NativeArray.getLengthProperty(cx, o, false);
+		Object callbackArg = args.length > 0 ? args[0] : Undefined.INSTANCE;
+		if (callbackArg == null || !(callbackArg instanceof Function f)) {
+			throw ScriptRuntime.notFunctionError(cx, callbackArg);
+		}
+		Scriptable parent = ScriptableObject.getTopLevelScope(f);
+		// hack to serve both reduce and reduceRight with the same loop
+		boolean movingLeft = operation == ReduceOperation.REDUCE;
+		Object value = args.length > 1 ? args[1] : Scriptable.NOT_FOUND;
+		for (long i = 0; i < length; i++) {
+			long index = movingLeft ? i : (length - 1 - i);
+			Object elem = getRawElem(o, index, cx);
+			if (elem == Scriptable.NOT_FOUND) {
+				continue;
+			}
+			if (value == Scriptable.NOT_FOUND) {
+				// no initial value passed, use first element found as inital value
+				value = elem;
+			} else {
+				Object[] innerArgs = {value, elem, index, o};
+				value = f.call(cx, parent, parent, innerArgs);
+			}
+		}
+		if (value == Scriptable.NOT_FOUND) {
+			// reproduce spidermonkey error message
+			throw ScriptRuntime.typeError0(cx, "msg.empty.array.reduce");
+		}
+		return value;
+	}
+
+	public static Comparator<Object> getSortComparator(final Context cx, final Scriptable scope, final Object[] args) {
+		if (args.length > 0 && Undefined.INSTANCE != args[0]) {
+			return getSortComparatorFromArguments(cx, scope, args);
+		}
+		return new ElementComparator(new StringLikeComparator(cx));
+	}
+
+	public static ElementComparator getSortComparatorFromArguments(final Context cx, final Scriptable scope, final Object[] args) {
+		final Callable jsCompareFunction = ScriptRuntime.getValueFunctionAndThis(cx, args[0]);
+		final Scriptable funThis = cx.lastStoredScriptable();
+		final Object[] cmpBuf = new Object[2]; // Buffer for cmp arguments
+		return new ElementComparator((x, y) -> {
+			// This comparator is invoked only for non-undefined objects
+			cmpBuf[0] = x;
+			cmpBuf[1] = y;
+			Object ret = jsCompareFunction.call(cx, scope, funThis, cmpBuf);
+			double d = ScriptRuntime.toNumber(cx, ret);
+			int cmp = Double.compare(d, 0);
+			if (cmp < 0) {
+				return -1;
+			} else if (cmp > 0) {
+				return +1;
+			}
+			return 0;
+		});
+	}
+
+	// Comparators for the js_sort method. Putting them here lets us unit-test them better.
+
+	public record StringLikeComparator(Context cx) implements Comparator<Object> {
+		@Override
+		public int compare(final Object x, final Object y) {
+			final String a = ScriptRuntime.toString(cx, x);
+			final String b = ScriptRuntime.toString(cx, y);
+			return a.compareTo(b);
+		}
+	}
+
+	public record ElementComparator(Comparator<Object> child) implements Comparator<Object> {
+		@Override
+		public int compare(final Object x, final Object y) {
+			// Sort NOT_FOUND to very end, Undefined before that, exclusively, as per
+			// ECMA 22.1.3.25.1.
+			if (x == Undefined.INSTANCE) {
+				if (y == Undefined.INSTANCE) {
+					return 0;
+				}
+				if (y == Scriptable.NOT_FOUND) {
+					return -1;
+				}
+				return 1;
+			} else if (x == Scriptable.NOT_FOUND) {
+				return y == Scriptable.NOT_FOUND ? 0 : 1;
+			}
+
+			if (y == Scriptable.NOT_FOUND) {
+				return -1;
+			}
+			if (y == Undefined.INSTANCE) {
+				return -1;
+			}
+
+			return child.compare(x, y);
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
+++ b/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
@@ -441,7 +441,11 @@ public class BaseFunction extends IdScriptableObject implements Function {
 		return result;
 	}
 
-	private synchronized Object setupDefaultPrototype(Context cx) {
+	protected void setPrototypeProperty(Object prototype) {
+		this.prototypeProperty = prototype;
+	}
+
+	protected synchronized Object setupDefaultPrototype(Context cx) {
 		if (prototypeProperty != null) {
 			return prototypeProperty;
 		}

--- a/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
+++ b/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
@@ -39,6 +39,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
 		BaseFunction obj = new BaseFunction();
 		// Function.prototype attributes: see ECMA 15.3.3.1
 		obj.prototypePropertyAttributes = DONTENUM | READONLY | PERMANENT;
+		obj.setStandardPropertyAttributes(READONLY | DONTENUM);
 		obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed, cx);
 	}
 
@@ -75,6 +76,10 @@ public class BaseFunction extends IdScriptableObject implements Function {
 	// see ECMA 15.3.5.2
 	private int prototypePropertyAttributes = PERMANENT | DONTENUM;
 	private int argumentsAttributes = PERMANENT | DONTENUM;
+	// "-1" means the property has been deleted
+	private int namePropertyAttributes = PERMANENT | READONLY | DONTENUM;
+	private int lengthPropertyAttributes = PERMANENT | READONLY | DONTENUM;
+	private int arityPropertyAttributes = PERMANENT | READONLY | DONTENUM;
 
 	public BaseFunction() {
 	}
@@ -138,33 +143,34 @@ public class BaseFunction extends IdScriptableObject implements Function {
 
 	@Override
 	protected int findInstanceIdInfo(String s, Context cx) {
-		int id = switch (s) {
-			case "name" -> Id_name;
-			case "length" -> Id_length;
-			case "arity" -> Id_arity;
-			case "prototype" -> Id_prototype;
-			case "arguments" -> Id_arguments;
-			default -> 0;
-		};
-
-		if (id == 0) {
-			return super.findInstanceIdInfo(s, cx);
-		}
-
-		int attr;
-		switch (id) {
-			case Id_length, Id_arity, Id_name -> attr = DONTENUM | READONLY | PERMANENT;
-			case Id_prototype -> {
-				// some functions such as built-ins don't have a prototype property
-				if (!hasPrototypeProperty()) {
-					return 0;
+		switch (s) {
+			case "length" -> {
+				if (lengthPropertyAttributes >= 0) {
+					return instanceIdInfo(lengthPropertyAttributes, Id_length);
 				}
-				attr = prototypePropertyAttributes;
 			}
-			case Id_arguments -> attr = argumentsAttributes;
-			default -> throw new IllegalStateException();
+			case "arity" -> {
+				if (arityPropertyAttributes >= 0) {
+					return instanceIdInfo(arityPropertyAttributes, Id_arity);
+				}
+			}
+			case "name" -> {
+				if (namePropertyAttributes >= 0) {
+					return instanceIdInfo(namePropertyAttributes, Id_name);
+				}
+			}
+			case "prototype" -> {
+				// some functions such as built-ins don't have a prototype property
+				if (hasPrototypeProperty()) {
+					return instanceIdInfo(prototypePropertyAttributes, Id_prototype);
+				}
+			}
+			case "arguments" -> {
+				return instanceIdInfo(argumentsAttributes, Id_arguments);
+			}
 		}
-		return instanceIdInfo(attr, id);
+
+		return super.findInstanceIdInfo(s, cx);
 	}
 
 	@Override
@@ -182,9 +188,9 @@ public class BaseFunction extends IdScriptableObject implements Function {
 	@Override
 	protected Object getInstanceIdValue(int id, Context cx) {
 		return switch (id) {
-			case Id_length -> getLength();
-			case Id_arity -> getArity();
-			case Id_name -> getFunctionName();
+			case Id_length -> lengthPropertyAttributes >= 0 ? getLength() : NOT_FOUND;
+			case Id_arity -> arityPropertyAttributes >= 0 ? getArity() : NOT_FOUND;
+			case Id_name -> namePropertyAttributes >= 0 ? getFunctionName() : NOT_FOUND;
 			case Id_prototype -> getPrototypeProperty(cx);
 			case Id_arguments -> getArguments(cx);
 			default -> super.getInstanceIdValue(id, cx);
@@ -211,8 +217,19 @@ public class BaseFunction extends IdScriptableObject implements Function {
 				}
 				return;
 			case Id_name:
+				if (value == NOT_FOUND) {
+					namePropertyAttributes = -1;
+				}
+				return;
 			case Id_arity:
+				if (value == NOT_FOUND) {
+					arityPropertyAttributes = -1;
+				}
+				return;
 			case Id_length:
+				if (value == NOT_FOUND) {
+					lengthPropertyAttributes = -1;
+				}
 				return;
 		}
 		super.setInstanceIdValue(id, value, cx);
@@ -227,6 +244,18 @@ public class BaseFunction extends IdScriptableObject implements Function {
 			}
 			case Id_arguments -> {
 				argumentsAttributes = attr;
+				return;
+			}
+			case Id_arity -> {
+				arityPropertyAttributes = attr;
+				return;
+			}
+			case Id_name -> {
+				namePropertyAttributes = attr;
+				return;
+			}
+			case Id_length -> {
+				lengthPropertyAttributes = attr;
 				return;
 			}
 		}
@@ -317,6 +346,11 @@ public class BaseFunction extends IdScriptableObject implements Function {
 	 * Make value as DontEnum, DontDelete, ReadOnly
 	 * prototype property of this Function object
 	 */
+	public void setStandardPropertyAttributes(int attributes) {
+		namePropertyAttributes = attributes;
+		lengthPropertyAttributes = attributes;
+	}
+
 	public void setImmunePrototypeProperty(Object value) {
 		if ((prototypePropertyAttributes & READONLY) != 0) {
 			throw new IllegalStateException();

--- a/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
+++ b/src/main/java/dev/latvian/mods/rhino/BaseFunction.java
@@ -230,7 +230,6 @@ public class BaseFunction extends IdScriptableObject implements Function {
 				return;
 			}
 		}
-		super.setInstanceIdAttributes(id, attr, cx);
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/rhino/Constructable.java
+++ b/src/main/java/dev/latvian/mods/rhino/Constructable.java
@@ -1,0 +1,20 @@
+package dev.latvian.mods.rhino;
+
+/**
+ * An interface that can be used to implement a constructor function as a lambda.
+ */
+public interface Constructable {
+	/**
+	 * Call the function as a constructor.
+	 * <p>
+	 * This method is invoked by the runtime in order to satisfy a use of the JavaScript
+	 * <code>new</code> operator.  This method is expected to create a new object and return it.
+	 *
+	 * @param cx    the current Context for this thread
+	 * @param scope an enclosing scope of the caller except when the function is called from a
+	 *              closure.
+	 * @param args  the array of arguments
+	 * @return the allocated object
+	 */
+	Scriptable construct(Context cx, Scriptable scope, Object[] args);
+}

--- a/src/main/java/dev/latvian/mods/rhino/Function.java
+++ b/src/main/java/dev/latvian/mods/rhino/Function.java
@@ -16,7 +16,7 @@ package dev.latvian.mods.rhino;
  * @see Scriptable
  */
 
-public interface Function extends Scriptable, Callable {
+public interface Function extends Scriptable, Callable, Constructable {
 	/**
 	 * Call the function.
 	 * <p>
@@ -47,5 +47,6 @@ public interface Function extends Scriptable, Callable {
 	 * @param args  the array of arguments
 	 * @return the allocated object
 	 */
+	@Override
 	Scriptable construct(Context cx, Scriptable scope, Object[] args);
 }

--- a/src/main/java/dev/latvian/mods/rhino/IdScriptableObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/IdScriptableObject.java
@@ -853,7 +853,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 	}
 
 	@Override
-	public void defineOwnProperty(Context cx, Object key, ScriptableObject desc) {
+	protected void defineOwnProperty(Context cx, Object key, ScriptableObject desc, boolean checkValid) {
 		if (key instanceof String name) {
 			int info = findInstanceIdInfo(name, cx);
 			if (info != 0) {
@@ -906,7 +906,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 				}
 			}
 		}
-		super.defineOwnProperty(cx, key, desc);
+		super.defineOwnProperty(cx, key, desc, checkValid);
 	}
 
 

--- a/src/main/java/dev/latvian/mods/rhino/Interpreter.java
+++ b/src/main/java/dev/latvian/mods/rhino/Interpreter.java
@@ -1531,13 +1531,7 @@ public final class Interpreter extends Icode implements Evaluator {
 						throw Kit.codeBug();
 				}
 			}
-			valBln = switch (op) {
-				case Token.GE -> ScriptRuntime.cmp_LE(cx, rhs, lhs);
-				case Token.LE -> ScriptRuntime.cmp_LE(cx, lhs, rhs);
-				case Token.GT -> ScriptRuntime.cmp_LT(cx, rhs, lhs);
-				case Token.LT -> ScriptRuntime.cmp_LT(cx, lhs, rhs);
-				default -> throw Kit.codeBug();
-			};
+			valBln = ScriptRuntime.compare(cx, lhs, rhs, op);
 		}
 		stack[stackTop] = valBln;
 		return stackTop;

--- a/src/main/java/dev/latvian/mods/rhino/JavaScriptException.java
+++ b/src/main/java/dev/latvian/mods/rhino/JavaScriptException.java
@@ -32,6 +32,18 @@ public class JavaScriptException extends RhinoException {
 		this.localContext = cx;
 		recordErrorOrigin(sourceName, lineNumber, null, 0);
 		this.value = value;
+		// try to extract the cause. Value can be either a (wrapped) java.lang.Throwable
+		// or a NativeError, that may contain the causing javaException
+		Object javaCause = value;
+		if (value instanceof NativeError error) {
+			javaCause = error.get(cx, "javaException", error);
+		}
+		if (javaCause instanceof Wrapper wrapper) {
+			javaCause = wrapper.unwrap();
+		}
+		if (javaCause instanceof Throwable throwable && throwable != this) {
+			this.initCause(throwable);
+		}
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/rhino/LambdaConstructor.java
+++ b/src/main/java/dev/latvian/mods/rhino/LambdaConstructor.java
@@ -1,0 +1,139 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package dev.latvian.mods.rhino;
+
+/**
+ * This class implements a JavaScript function that may be used as a constructor by delegating to an
+ * interface that can be easily implemented as a lambda. The LambdaFunction class may be used to add
+ * functions to the prototype that are also implemented as lambdas.
+ * <p>
+ * In micro benchmarks (as of 2021) using this class to implement a built-in class is about
+ * 15% more efficient than using IdScriptableObject, and about 25% faster than using reflection
+ * via the ScriptableObject.defineClass() family of methods. Furthermore, it results in
+ * code that more directly maps to JavaScript idioms than either methods, it is much easier
+ * to implement than IdScriptableObject, and the lambda pattern makes it easier to maintain
+ * state in various ways that don't always map directly to the existing concepts.
+ */
+public class LambdaConstructor extends LambdaFunction {
+	/**
+	 * If this flag is set, the constructor may be invoked as an ordinary function
+	 */
+	public static final int CONSTRUCTOR_FUNCTION = 1;
+	/**
+	 * If this flag is set, the constructor may be invoked using "new"
+	 */
+	public static final int CONSTRUCTOR_NEW = 1 << 1;
+	/**
+	 * By default, the constructor may be invoked either way
+	 */
+	public static final int CONSTRUCTOR_DEFAULT = CONSTRUCTOR_FUNCTION | CONSTRUCTOR_NEW;
+
+	/**
+	 * A convenience method to convert JavaScript's "this" object into a target class and
+	 * throw a TypeError if it does not match. This is useful for implementing lambda
+	 * functions, as "this" in JavaScript doesn't necessarily map to an instance of the
+	 * class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T convertThisObject(Context cx, Scriptable thisObj, Class<T> targetClass) {
+		if (!targetClass.isInstance(thisObj)) {
+			throw ScriptRuntime.typeError0(cx, "msg.this.not.instance");
+		}
+		return (T) thisObj;
+	}
+
+	// Lambdas should not be serialized.
+	private final transient Constructable targetConstructor;
+	private final int flags;
+
+	/**
+	 * Create a new function that may be used as a constructor. The new object will have the
+	 * Function prototype and no parent. The caller is responsible for binding this object
+	 * to the appropriate scope.
+	 *
+	 * @param cx     the current Context for this thread
+	 * @param scope  scope of the calling context
+	 * @param name   name of the function
+	 * @param length the arity of the function
+	 * @param target an object that implements the function in Java. Since Constructable is a
+	 *               single-function interface this will typically be implemented as a lambda.
+	 */
+	public LambdaConstructor(Context cx, Scriptable scope, String name, int length, Constructable target) {
+		super(cx, scope, name, length, null);
+		this.targetConstructor = target;
+		this.flags = CONSTRUCTOR_DEFAULT;
+	}
+
+	/**
+	 * Create a new function and control whether it may be invoked using new, as a function,
+	 * or both.
+	 */
+	public LambdaConstructor(Context cx, Scriptable scope, String name, int length, int flags, Constructable target) {
+		super(cx, scope, name, length, null);
+		this.targetConstructor = target;
+		this.flags = flags;
+	}
+
+	@Override
+	public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		if ((flags & CONSTRUCTOR_FUNCTION) == 0) {
+			throw ScriptRuntime.typeError1(cx, "msg.constructor.no.function", getFunctionName());
+		}
+		return targetConstructor.construct(cx, scope, args);
+	}
+
+	@Override
+	public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
+		if ((flags & CONSTRUCTOR_NEW) == 0) {
+			throw ScriptRuntime.typeError1(cx, "msg.no.new", getFunctionName());
+		}
+		Scriptable obj = targetConstructor.construct(cx, scope, args);
+		obj.setPrototype(getClassPrototype(cx));
+		obj.setParentScope(scope);
+		return obj;
+	}
+
+	/**
+	 * Define a function property on the prototype of the constructor using a LambdaFunction under the
+	 * covers.
+	 */
+	public void definePrototypeMethod(Context cx, Scriptable scope, String name, int length, Callable target) {
+		LambdaFunction f = new LambdaFunction(cx, scope, name, length, target);
+		ScriptableObject proto = getPrototypeScriptable(cx);
+		proto.defineProperty(cx, name, f, 0);
+	}
+
+	/**
+	 * Define a property that may be of any type on the prototype of this constructor.
+	 */
+	public void definePrototypeProperty(Context cx, String name, Object value, int attributes) {
+		ScriptableObject proto = getPrototypeScriptable(cx);
+		proto.defineProperty(cx, name, value, attributes);
+	}
+
+	public void definePrototypeProperty(Context cx, Symbol key, Object value, int attributes) {
+		ScriptableObject proto = getPrototypeScriptable(cx);
+		proto.defineProperty(cx, key, value, attributes);
+	}
+
+	/**
+	 * Define a function property directly on the constructor that is implemented under the
+	 * covers by a LambdaFunction.
+	 */
+	public void defineConstructorMethod(Context cx, Scriptable scope, String name, int length, Callable target) {
+		LambdaFunction f = new LambdaFunction(cx, scope, name, length, target);
+		defineProperty(cx, name, f, DONTENUM);
+	}
+
+	private ScriptableObject getPrototypeScriptable(Context cx) {
+		Object prop = getPrototypeProperty(cx);
+		if (!(prop instanceof ScriptableObject)) {
+			throw ScriptRuntime.typeError(cx, "Not properly a lambda constructor");
+		}
+		return (ScriptableObject) prop;
+	}
+}

--- a/src/main/java/dev/latvian/mods/rhino/LambdaFunction.java
+++ b/src/main/java/dev/latvian/mods/rhino/LambdaFunction.java
@@ -1,0 +1,73 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package dev.latvian.mods.rhino;
+
+/**
+ * This class implements a single JavaScript function that has the prototype of the built-in
+ * Function class, and which is implemented using a single function that can easily be implemented
+ * using a lambda expression.
+ */
+public class LambdaFunction extends BaseFunction {
+	// The target is expected to be a lambda -- lambdas should not be serialized.
+	private final transient Callable target;
+	private final String name;
+	private final int length;
+
+	/**
+	 * Create a new function. The new object will have the Function prototype and no parent. The
+	 * caller is responsible for binding this object to the appropriate scope.
+	 *
+	 * @param cx     the current Context for this thread
+	 * @param scope  scope of the calling context
+	 * @param name   name of the function
+	 * @param length the arity of the function
+	 * @param target an object that implements the function in Java. Since Callable is a
+	 *               single-function interface this will typically be implemented as a lambda.
+	 */
+	public LambdaFunction(Context cx, Scriptable scope, String name, int length, Callable target) {
+		this.target = target;
+		this.name = name;
+		this.length = length;
+		ScriptRuntime.setFunctionProtoAndParent(cx, scope, this);
+		setupDefaultPrototype(cx);
+	}
+
+	/**
+	 * Create a new built-in function, with no name, and no default prototype.
+	 */
+	public LambdaFunction(Context cx, Scriptable scope, int length, Callable target) {
+		this.target = target;
+		this.length = length;
+		this.name = "";
+		ScriptRuntime.setFunctionProtoAndParent(cx, scope, this);
+	}
+
+	@Override
+	public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		return target.call(cx, scope, thisObj, args);
+	}
+
+	@Override
+	public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
+		throw ScriptRuntime.typeError1(cx, "msg.no.new", getFunctionName());
+	}
+
+	@Override
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public int getArity() {
+		return length;
+	}
+
+	@Override
+	public String getFunctionName() {
+		return name;
+	}
+}

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -6,6 +6,8 @@
 
 package dev.latvian.mods.rhino;
 
+import dev.latvian.mods.rhino.ArrayLikeAbstractOperations.IterativeOperation;
+import dev.latvian.mods.rhino.ArrayLikeAbstractOperations.ReduceOperation;
 import dev.latvian.mods.rhino.regexp.NativeRegExp;
 import dev.latvian.mods.rhino.util.DataObject;
 
@@ -115,43 +117,6 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	 * The maximum size of <code>dense</code> that will be allocated initially.
 	 */
 	private static int maximumInitialCapacity = 10000;
-
-	public record StringLikeComparator(Context cx) implements Comparator<Object> {
-		@Override
-		public int compare(final Object x, final Object y) {
-			final String a = ScriptRuntime.toString(cx, x);
-			final String b = ScriptRuntime.toString(cx, y);
-			return a.compareTo(b);
-		}
-	}
-
-	public record ElementComparator(Comparator<Object> child) implements Comparator<Object> {
-		@Override
-		public int compare(final Object x, final Object y) {
-			// Sort NOT_FOUND to very end, Undefined before that, exclusively, as per
-			// ECMA 22.1.3.25.1.
-			if (x == Undefined.INSTANCE) {
-				if (y == Undefined.INSTANCE) {
-					return 0;
-				}
-				if (y == NOT_FOUND) {
-					return -1;
-				}
-				return 1;
-			} else if (x == NOT_FOUND) {
-				return y == NOT_FOUND ? 0 : 1;
-			}
-
-			if (y == NOT_FOUND) {
-				return -1;
-			}
-			if (y == Undefined.INSTANCE) {
-				return -1;
-			}
-
-			return child.compare(x, y);
-		}
-	}
 
 	static void init(Scriptable scope, boolean sealed, Context cx) {
 		NativeArray obj = new NativeArray(cx, 0);
@@ -276,7 +241,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 						if (mapping) {
 							temp = mapFn.call(cx, scope, thisArg, new Object[]{temp, k});
 						}
-						defineElem(cx, result, k, temp);
+						ArrayLikeAbstractOperations.defineElem(cx, result, k, temp);
 						k++;
 					}
 				}
@@ -292,7 +257,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			if (mapping) {
 				temp = mapFn.call(cx, scope, thisArg, new Object[]{temp, k});
 			}
-			defineElem(cx, result, k, temp);
+			ArrayLikeAbstractOperations.defineElem(cx, result, k, temp);
 		}
 
 		setLengthProperty(cx, result, length);
@@ -303,7 +268,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		final Scriptable result = callConstructorOrCreateArray(cx, scope, thisObj, args.length, true);
 
 		for (int i = 0; i < args.length; i++) {
-			defineElem(cx, result, i, args[i]);
+			ArrayLikeAbstractOperations.defineElem(cx, result, i, args[i]);
 		}
 		setLengthProperty(cx, result, args.length);
 
@@ -366,25 +331,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	}
 
 	private static Object getElem(Context cx, Scriptable target, long index) {
-		Object elem = getRawElem(target, index, cx);
+		Object elem = ArrayLikeAbstractOperations.getRawElem(target, index, cx);
 		return (elem != NOT_FOUND ? elem : Undefined.INSTANCE);
-	}
-
-	// same as getElem, but without converting NOT_FOUND to undefined
-	private static Object getRawElem(Scriptable target, long index, Context cx) {
-		if (index > Integer.MAX_VALUE) {
-			return getProperty(target, Long.toString(index), cx);
-		}
-		return getProperty(target, (int) index, cx);
-	}
-
-	private static void defineElem(Context cx, Scriptable target, long index, Object value) {
-		if (index > Integer.MAX_VALUE) {
-			String id = Long.toString(index);
-			target.put(cx, id, target, value);
-		} else {
-			target.put(cx, (int) index, target, value);
-		}
 	}
 
 	private static void setElem(Context cx, Scriptable target, long index, Object value) {
@@ -422,7 +370,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			if (i > 0) {
 				result.append(", ");
 			}
-			Object elem = getRawElem(o, i, cx);
+			Object elem = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 			if (elem == NOT_FOUND || elem == null || elem == Undefined.INSTANCE) {
 				continue;
 			}
@@ -451,7 +399,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			if (i > 0) {
 				result.append(", ");
 			}
-			Object elem = getRawElem(o, i, cx);
+			Object elem = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 			if (elem == NOT_FOUND || elem == null || elem == Undefined.INSTANCE) {
 				continue;
 			}
@@ -542,8 +490,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		long half = len / 2;
 		for (long i = 0; i < half; i++) {
 			long j = len - i - 1;
-			Object temp1 = getRawElem(o, i, cx);
-			Object temp2 = getRawElem(o, j, cx);
+			Object temp1 = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
+			Object temp2 = ArrayLikeAbstractOperations.getRawElem(o, j, cx);
 			setRawElem(cx, o, i, temp2);
 			setRawElem(cx, o, j, temp1);
 		}
@@ -556,28 +504,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static Scriptable js_sort(final Context cx, final Scriptable scope, final Scriptable thisObj, final Object[] args) {
 		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
-		final Comparator<Object> comparator;
-		if (args.length > 0 && Undefined.INSTANCE != args[0]) {
-			final Callable jsCompareFunction = ScriptRuntime.getValueFunctionAndThis(cx, args[0]);
-			final Scriptable funThis = cx.lastStoredScriptable();
-			final Object[] cmpBuf = new Object[2]; // Buffer for cmp arguments
-			comparator = new ElementComparator((x, y) -> {
-				// This comparator is invoked only for non-undefined objects
-				cmpBuf[0] = x;
-				cmpBuf[1] = y;
-				Object ret = jsCompareFunction.call(cx, scope, funThis, cmpBuf);
-				double d = ScriptRuntime.toNumber(cx, ret);
-				int cmp = Double.compare(d, 0);
-				if (cmp < 0) {
-					return -1;
-				} else if (cmp > 0) {
-					return +1;
-				}
-				return 0;
-			});
-		} else {
-			comparator = new ElementComparator(new StringLikeComparator(cx));
-		}
+		final Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
 
 		long llength = getLengthProperty(cx, o, false);
 		final int length = (int) llength;
@@ -588,7 +515,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		// sorted cheaply.
 		final Object[] working = new Object[length];
 		for (int i = 0; i != length; ++i) {
-			working[i] = getRawElem(o, i, cx);
+			working[i] = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 		}
 
 		Sorting.get().hybridSort(working, comparator);
@@ -681,7 +608,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			 */
 			if (length > 0) {
 				for (i = 1; i <= length; i++) {
-					Object temp = getRawElem(o, i, cx);
+					Object temp = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 					setRawElem(cx, o, i - 1, temp);
 				}
 			}
@@ -713,7 +640,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			/*  Slide up the array to make room for args at the bottom */
 			if (length > 0) {
 				for (long last = length - 1; last >= 0; last--) {
-					Object temp = getRawElem(o, last, cx);
+					Object temp = ArrayLikeAbstractOperations.getRawElem(o, last, cx);
 					setRawElem(cx, o, last + argc, temp);
 				}
 			}
@@ -747,7 +674,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		long length = getLengthProperty(cx, o, false);
 
 		/* Convert the first argument into a starting index. */
-		long begin = toSliceIndex(ScriptRuntime.toInteger(cx, args[0]), length);
+		long begin = ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(cx, args[0]), length);
 		argc--;
 
 		/* Convert the second argument into count */
@@ -779,7 +706,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			} else {
 				Scriptable resultArray = cx.newArray(scope, 0);
 				for (long last = begin; last != end; last++) {
-					Object temp = getRawElem(o, last, cx);
+					Object temp = ArrayLikeAbstractOperations.getRawElem(o, last, cx);
 					if (temp != NOT_FOUND) {
 						setElem(cx, resultArray, last - begin, temp);
 					}
@@ -808,12 +735,12 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 
 		if (delta > 0) {
 			for (long last = length - 1; last >= end; last--) {
-				Object temp = getRawElem(o, last, cx);
+				Object temp = ArrayLikeAbstractOperations.getRawElem(o, last, cx);
 				setRawElem(cx, o, last + delta, temp);
 			}
 		} else if (delta < 0) {
 			for (long last = end; last < length; last++) {
-				Object temp = getRawElem(o, last, cx);
+				Object temp = ArrayLikeAbstractOperations.getRawElem(o, last, cx);
 				setRawElem(cx, o, last + delta, temp);
 			}
 			// Do this backwards because some implementations might use a
@@ -874,21 +801,19 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		// If we get here then we have to do things the generic way
 		long dstpos = offset;
 		for (long srcpos = 0; srcpos < srclen; srcpos++, dstpos++) {
-			final Object temp = getRawElem(arg, srcpos, cx);
+			final Object temp = ArrayLikeAbstractOperations.getRawElem(arg, srcpos, cx);
 			if (temp != NOT_FOUND) {
-				defineElem(cx, result, dstpos, temp);
+				ArrayLikeAbstractOperations.defineElem(cx, result, dstpos, temp);
 			}
 		}
 		return newlen;
 	}
 
-	// Comparators for the js_sort method. Putting them here lets us unit-test them better.
-
 	private static long doConcat(Context cx, Scriptable scope, Scriptable result, Object arg, long offset) {
 		if (isConcatSpreadable(cx, scope, arg)) {
 			return concatSpreadArg(cx, result, (Scriptable) arg, offset);
 		}
-		defineElem(cx, result, offset, arg);
+		ArrayLikeAbstractOperations.defineElem(cx, result, offset, arg);
 		return offset + 1;
 	}
 
@@ -922,38 +847,22 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			begin = 0;
 			end = len;
 		} else {
-			begin = toSliceIndex(ScriptRuntime.toInteger(cx, args[0]), len);
+			begin = ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(cx, args[0]), len);
 			if (args.length == 1 || args[1] == Undefined.INSTANCE) {
 				end = len;
 			} else {
-				end = toSliceIndex(ScriptRuntime.toInteger(cx, args[1]), len);
+				end = ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(cx, args[1]), len);
 			}
 		}
 
 		for (long slot = begin; slot < end; slot++) {
-			Object temp = getRawElem(o, slot, cx);
+			Object temp = ArrayLikeAbstractOperations.getRawElem(o, slot, cx);
 			if (temp != NOT_FOUND) {
-				defineElem(cx, result, slot - begin, temp);
+				ArrayLikeAbstractOperations.defineElem(cx, result, slot - begin, temp);
 			}
 		}
 		setLengthProperty(cx, result, Math.max(0, end - begin));
 
-		return result;
-	}
-
-	private static long toSliceIndex(double value, long length) {
-		long result;
-		if (value < 0.0) {
-			if (value + length < 0.0) {
-				result = 0;
-			} else {
-				result = (long) (value + length);
-			}
-		} else if (value > length) {
-			result = length;
-		} else {
-			result = (long) value;
-		}
 		return result;
 	}
 
@@ -1004,7 +913,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			}
 		}
 		for (long i = start; i < length; i++) {
-			Object val = getRawElem(o, i, cx);
+			Object val = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 			if (val != NOT_FOUND && ScriptRuntime.shallowEq(cx, val, compareTo)) {
 				return i;
 			}
@@ -1059,7 +968,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			}
 		}
 		for (long i = start; i >= 0; i--) {
-			Object val = getRawElem(o, i, cx);
+			Object val = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 			if (val != NOT_FOUND && ScriptRuntime.shallowEq(cx, val, compareTo)) {
 				return i;
 			}
@@ -1113,7 +1022,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			}
 		}
 		for (; k < len; k++) {
-			Object elementK = getRawElem(o, k, cx);
+			Object elementK = ArrayLikeAbstractOperations.getRawElem(o, k, cx);
 			if (elementK == NOT_FOUND) {
 				elementK = Undefined.INSTANCE;
 			}
@@ -1214,7 +1123,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		}
 
 		for (; count > 0; count--) {
-			final Object temp = getRawElem(o, from, cx);
+			final Object temp = ArrayLikeAbstractOperations.getRawElem(o, from, cx);
 			if ((temp == NOT_FOUND) || Undefined.isUndefined(temp)) {
 				deleteElem(o, to, cx);
 			} else {
@@ -1261,7 +1170,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		Scriptable result = cx.newArray(scope, 0);
 		long j = 0;
 		for (long i = 0; i < length; i++) {
-			Object elem = getRawElem(source, i, cx);
+			Object elem = ArrayLikeAbstractOperations.getRawElem(source, i, cx);
 			if (elem == NOT_FOUND) {
 				continue;
 			}
@@ -1269,11 +1178,11 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				Scriptable arr = flat(cx, scope, (Scriptable) elem, depth - 1);
 				long arrLength = getLengthProperty(cx, arr, false);
 				for (long k = 0; k < arrLength; k++) {
-					Object temp = getRawElem(arr, k, cx);
-					defineElem(cx, result, j++, temp);
+					Object temp = ArrayLikeAbstractOperations.getRawElem(arr, k, cx);
+					ArrayLikeAbstractOperations.defineElem(cx, result, j++, temp);
 				}
 			} else {
-				defineElem(cx, result, j++, elem);
+				ArrayLikeAbstractOperations.defineElem(cx, result, j++, elem);
 			}
 		}
 		setLengthProperty(cx, result, j);
@@ -1300,7 +1209,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		Scriptable result = cx.newArray(scope, 0);
 		long j = 0;
 		for (long i = 0; i < length; i++) {
-			Object elem = getRawElem(o, i, cx);
+			Object elem = ArrayLikeAbstractOperations.getRawElem(o, i, cx);
 			if (elem == NOT_FOUND) {
 				continue;
 			}
@@ -1310,11 +1219,11 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				Scriptable arr = (Scriptable) mapCall;
 				long arrLength = getLengthProperty(cx, arr, false);
 				for (long k = 0; k < arrLength; k++) {
-					Object temp = getRawElem(arr, k, cx);
-					defineElem(cx, result, j++, temp);
+					Object temp = ArrayLikeAbstractOperations.getRawElem(arr, k, cx);
+					ArrayLikeAbstractOperations.defineElem(cx, result, j++, temp);
 				}
 			} else {
-				defineElem(cx, result, j++, mapCall);
+				ArrayLikeAbstractOperations.defineElem(cx, result, j++, mapCall);
 			}
 		}
 		setLengthProperty(cx, result, j);
@@ -1324,138 +1233,6 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	/**
 	 * Implements the methods "every", "filter", "forEach", "map", and "some".
 	 */
-	private static Object iterativeMethod(Context cx, IdFunctionObject idFunctionObject, Scriptable scope, Scriptable thisObj, Object[] args) {
-		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-
-		// execIdCall(..) uses a trick for all the ConstructorId_xxx calls
-		// they are handled like object calls by adjusting the args list
-		// as a result we have to handle ConstructorId_xxx calls (negative id)
-		// the same way and always us the abs value of the id for method selection
-		int id = Math.abs(idFunctionObject.methodId());
-		if (Id_find == id || Id_findIndex == id) {
-			ScriptRuntimeES6.requireObjectCoercible(cx, o, idFunctionObject);
-		}
-
-		long length = getLengthProperty(cx, o, id == Id_map);
-		Object callbackArg = args.length > 0 ? args[0] : Undefined.INSTANCE;
-		if (callbackArg == null || !(callbackArg instanceof Function f)) {
-			throw ScriptRuntime.notFunctionError(cx, callbackArg);
-		}
-		if (callbackArg instanceof NativeRegExp) {
-			// Previously, it was allowed to pass RegExp instance as a callback (it implements Function)
-			// But according to ES2015 21.2.6 Properties of RegExp Instances:
-			// > RegExp instances are ordinary objects that inherit properties from the RegExp prototype object.
-			// > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]].
-			// so, no [[Call]] for RegExp-s
-			throw ScriptRuntime.notFunctionError(cx, callbackArg);
-		}
-
-		Scriptable parent = getTopLevelScope(f);
-		Scriptable thisArg;
-		if (args.length < 2 || args[1] == null || args[1] == Undefined.INSTANCE) {
-			thisArg = parent;
-		} else {
-			thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
-		}
-
-		Scriptable array = null;
-		if (id == Id_filter || id == Id_map) {
-			int resultLength = id == Id_map ? (int) length : 0;
-			array = cx.newArray(scope, resultLength);
-		}
-		long j = 0;
-		for (long i = 0; i < length; i++) {
-			Object[] innerArgs = new Object[3];
-			Object elem = getRawElem(o, i, cx);
-			if (elem == NOT_FOUND) {
-				if (id == Id_find || id == Id_findIndex) {
-					elem = Undefined.INSTANCE;
-				} else {
-					continue;
-				}
-			}
-			innerArgs[0] = elem;
-			innerArgs[1] = i;
-			innerArgs[2] = o;
-			Object result = f.call(cx, parent, thisArg, innerArgs);
-			switch (id) {
-				case Id_every:
-					if (!ScriptRuntime.toBoolean(cx, result)) {
-						return Boolean.FALSE;
-					}
-					break;
-				case Id_filter:
-					if (ScriptRuntime.toBoolean(cx, result)) {
-						defineElem(cx, array, j++, innerArgs[0]);
-					}
-					break;
-				case Id_forEach:
-					break;
-				case Id_map:
-					defineElem(cx, array, i, result);
-					break;
-				case Id_some:
-					if (ScriptRuntime.toBoolean(cx, result)) {
-						return Boolean.TRUE;
-					}
-					break;
-				case Id_find:
-					if (ScriptRuntime.toBoolean(cx, result)) {
-						return elem;
-					}
-					break;
-				case Id_findIndex:
-					if (ScriptRuntime.toBoolean(cx, result)) {
-						return ScriptRuntime.wrapNumber(i);
-					}
-					break;
-			}
-		}
-		return switch (id) {
-			case Id_every -> Boolean.TRUE;
-			case Id_filter, Id_map -> array;
-			case Id_some -> Boolean.FALSE;
-			case Id_findIndex -> ScriptRuntime.wrapNumber(-1);
-			default -> Undefined.INSTANCE;
-		};
-	}
-
-	/**
-	 * Implements the methods "reduce" and "reduceRight".
-	 */
-	private static Object reduceMethod(Context cx, int id, Scriptable scope, Scriptable thisObj, Object[] args) {
-		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-
-		long length = getLengthProperty(cx, o, false);
-		Object callbackArg = args.length > 0 ? args[0] : Undefined.INSTANCE;
-		if (callbackArg == null || !(callbackArg instanceof Function f)) {
-			throw ScriptRuntime.notFunctionError(cx, callbackArg);
-		}
-		Scriptable parent = getTopLevelScope(f);
-		// hack to serve both reduce and reduceRight with the same loop
-		boolean movingLeft = id == Id_reduce;
-		Object value = args.length > 1 ? args[1] : NOT_FOUND;
-		for (long i = 0; i < length; i++) {
-			long index = movingLeft ? i : (length - 1 - i);
-			Object elem = getRawElem(o, index, cx);
-			if (elem == NOT_FOUND) {
-				continue;
-			}
-			if (value == NOT_FOUND) {
-				// no initial value passed, use first element found as inital value
-				value = elem;
-			} else {
-				Object[] innerArgs = {value, elem, index, o};
-				value = f.call(cx, parent, parent, innerArgs);
-			}
-		}
-		if (value == NOT_FOUND) {
-			// reproduce spidermonkey error message
-			throw ScriptRuntime.typeError0(cx, "msg.empty.array.reduce");
-		}
-		return value;
-	}
-
 	private static boolean js_isArray(Object o) {
 		return o instanceof NativeJavaList || o instanceof List || o instanceof Scriptable s && "Array".equals(s.getClassName());
 	}
@@ -1876,16 +1653,23 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 					return js_flatMap(cx, scope, thisObj, args);
 
 				case Id_every:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.EVERY, scope, thisObj, args);
 				case Id_filter:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FILTER, scope, thisObj, args);
 				case Id_forEach:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FOR_EACH, scope, thisObj, args);
 				case Id_map:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.MAP, scope, thisObj, args);
 				case Id_some:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.SOME, scope, thisObj, args);
 				case Id_find:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND, scope, thisObj, args);
 				case Id_findIndex:
-					return iterativeMethod(cx, f, scope, thisObj, args);
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND_INDEX, scope, thisObj, args);
 				case Id_reduce:
+					return ArrayLikeAbstractOperations.reduceMethod(cx, ReduceOperation.REDUCE, scope, thisObj, args);
 				case Id_reduceRight:
-					return reduceMethod(cx, id, scope, thisObj, args);
+					return ArrayLikeAbstractOperations.reduceMethod(cx, ReduceOperation.REDUCE_RIGHT, scope, thisObj, args);
 
 				case Id_keys:
 					thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
@@ -2231,7 +2015,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		if (index < 0 || index >= length) {
 			throw new IndexOutOfBoundsException();
 		}
-		Object value = getRawElem(this, index, cx);
+		Object value = ArrayLikeAbstractOperations.getRawElem(this, index, cx);
 		if (value == NOT_FOUND || value == Undefined.INSTANCE) {
 			return null;
 		} else if (value instanceof Wrapper) {

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -1977,6 +1977,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			length = index + 1;
 		}
 		super.defineOwnProperty(cx, id, desc, checkValid);
+
+		if ("length".equals(id)) {
+			lengthAttr = getAttributes(cx, "length"); // Update cached attributes value for length property
+		}
 	}
 
 	public long getLength() {

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -285,13 +285,11 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		final long length = getLengthProperty(cx, items, false);
 		final Scriptable result = callConstructorOrCreateArray(cx, scope, thisObj, length, true);
 		for (long k = 0; k < length; k++) {
-			Object temp = getRawElem(items, k, cx);
-			if (temp != NOT_FOUND) {
-				if (mapping) {
-					temp = mapFn.call(cx, scope, thisArg, new Object[]{temp, k});
-				}
-				defineElem(cx, result, k, temp);
+			Object temp = getElem(cx, items, k);
+			if (mapping) {
+				temp = mapFn.call(cx, scope, thisArg, new Object[]{temp, k});
 			}
+			defineElem(cx, result, k, temp);
 		}
 
 		setLengthProperty(cx, result, length);

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -81,7 +81,11 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int Id_flatMap = 35;
 	private static final int Id_findLast = 36;
 	private static final int Id_findLastIndex = 37;
-	private static final int MAX_PROTOTYPE_ID = Id_findLastIndex;
+	private static final int Id_toReversed = 38;
+	private static final int Id_toSorted = 39;
+	private static final int Id_toSpliced = 40;
+	private static final int Id_with = 41;
+	private static final int MAX_PROTOTYPE_ID = Id_with;
 	private static final int ConstructorId_join = -Id_join;
 	private static final int ConstructorId_reverse = -Id_reverse;
 	private static final int ConstructorId_sort = -Id_sort;
@@ -505,11 +509,14 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	/**
 	 * See ECMA 15.4.4.5
 	 */
+
 	private static Scriptable js_sort(final Context cx, final Scriptable scope, final Scriptable thisObj, final Object[] args) {
 		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+		Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
+		return sort(cx, o, comparator);
+	}
 
-		final Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
-
+	private static Scriptable sort(final Context cx, final Scriptable o, final Comparator<Object> comparator) {
 		long llength = getLengthProperty(cx, o, false);
 		final int length = (int) llength;
 		if (llength != length) {
@@ -1238,6 +1245,131 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		return o instanceof NativeJavaList || o instanceof List || o instanceof Scriptable s && "Array".equals(s.getClassName());
 	}
 
+	private static Object js_toSorted(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
+
+		Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
+		long len = getLengthProperty(cx, source, false);
+
+		if (len > Integer.MAX_VALUE) {
+			String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+			throw ScriptRuntime.rangeError(cx, msg);
+		}
+		Scriptable result = cx.newArray(scope, (int) len);
+
+		for (int k = 0; k < len; ++k) {
+			Object fromValue = getElem(cx, source, k);
+			setElem(cx, result, k, fromValue);
+		}
+
+		sort(cx, result, comparator);
+		return result;
+	}
+
+	private static Object js_toReversed(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
+		long len = getLengthProperty(cx, source, false);
+
+		if (len > Integer.MAX_VALUE) {
+			String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+			throw ScriptRuntime.rangeError(cx, msg);
+		}
+		Scriptable result = cx.newArray(scope, (int) len);
+
+		for (int k = 0; k < len; ++k) {
+			int from = (int) len - k - 1;
+			Object fromValue = getElem(cx, source, from);
+			setElem(cx, result, k, fromValue);
+		}
+
+		return result;
+	}
+
+	private static Object js_toSpliced(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
+		long len = getLengthProperty(cx, source, false);
+
+		long actualStart = 0;
+		if (args.length > 0) {
+			actualStart = ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(cx, args[0]), len);
+		}
+
+		long insertCount = args.length > 2 ? args.length - 2 : 0;
+
+		long actualSkipCount;
+		if (args.length == 0) {
+			actualSkipCount = 0;
+		} else if (args.length == 1) {
+			actualSkipCount = len - actualStart;
+		} else {
+			long sc = ScriptRuntime.toLength(cx, args, 1);
+			actualSkipCount = Math.max(0, Math.min(sc, len - actualStart));
+		}
+
+		long newLen = len + insertCount - actualSkipCount;
+		if (newLen > NativeNumber.MAX_SAFE_INTEGER) {
+			throw ScriptRuntime.typeError1(cx, "msg.arraylength.too.big", String.valueOf(newLen));
+		}
+		if (newLen > Integer.MAX_VALUE) {
+			String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+			throw ScriptRuntime.rangeError(cx, msg);
+		}
+
+		Scriptable result = cx.newArray(scope, (int) newLen);
+
+		long i = 0;
+		long r = actualStart + actualSkipCount;
+
+		while (i < actualStart) {
+			Object e = getElem(cx, source, i);
+			setElem(cx, result, i, e);
+			i++;
+		}
+
+		for (int j = 2; j < args.length; j++) {
+			setElem(cx, result, i, args[j]);
+			i++;
+		}
+
+		while (i < newLen) {
+			Object e = getElem(cx, source, r);
+			setElem(cx, result, i, e);
+			i++;
+			r++;
+		}
+
+		return result;
+	}
+
+	private static Object js_with(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
+
+		long len = getLengthProperty(cx, source, false);
+		long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(cx, args[0]) : 0;
+		long actualIndex = relativeIndex >= 0 ? relativeIndex : len + relativeIndex;
+
+		if (actualIndex < 0 || actualIndex >= len) {
+			throw ScriptRuntime.rangeError(cx, "index out of range");
+		}
+		if (len > Integer.MAX_VALUE) {
+			String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+			throw ScriptRuntime.rangeError(cx, msg);
+		}
+
+		Scriptable result = cx.newArray(scope, (int) len);
+		for (long k = 0; k < len; ++k) {
+			Object value;
+			if (k == actualIndex) {
+				value = args.length > 1 ? args[1] : Undefined.INSTANCE;
+			} else {
+				value = getElem(cx, source, k);
+			}
+			setElem(cx, result, k, value);
+		}
+
+		return result;
+	}
+
 	private final Context localContext;
 
 	/**
@@ -1529,6 +1661,22 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				arity = 1;
 				s = "findLastIndex";
 			}
+			case Id_toReversed -> {
+				arity = 0;
+				s = "toReversed";
+			}
+			case Id_toSorted -> {
+				arity = 1;
+				s = "toSorted";
+			}
+			case Id_toSpliced -> {
+				arity = 2;
+				s = "toSpliced";
+			}
+			case Id_with -> {
+				arity = 2;
+				s = "with";
+			}
 			default -> throw new IllegalArgumentException(String.valueOf(id));
 		}
 
@@ -1664,6 +1812,18 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 
 				case Id_flatMap:
 					return js_flatMap(cx, scope, thisObj, args);
+
+				case Id_toReversed:
+					return js_toReversed(cx, scope, thisObj, args);
+
+				case Id_toSorted:
+					return js_toSorted(cx, scope, thisObj, args);
+
+				case Id_toSpliced:
+					return js_toSpliced(cx, scope, thisObj, args);
+
+				case Id_with:
+					return js_with(cx, scope, thisObj, args);
 
 				case Id_every:
 					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.EVERY, scope, thisObj, args);
@@ -2274,6 +2434,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			case "flatMap" -> Id_flatMap;
 			case "findLast" -> Id_findLast;
 			case "findLastIndex" -> Id_findLastIndex;
+			case "toReversed" -> Id_toReversed;
+			case "toSorted" -> Id_toSorted;
+			case "toSpliced" -> Id_toSpliced;
+			case "with" -> Id_with;
 			default -> 0;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -76,7 +76,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int SymbolId_iterator = 32;
 	private static final int Id_at = 33;
 	private static final int Id_flat = 34;
-	private static final int MAX_PROTOTYPE_ID = Id_flat;
+	private static final int Id_flatMap = 35;
+	private static final int MAX_PROTOTYPE_ID = Id_flatMap;
 	private static final int ConstructorId_join = -Id_join;
 	private static final int ConstructorId_reverse = -Id_reverse;
 	private static final int ConstructorId_sort = -Id_sort;
@@ -1279,6 +1280,47 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		return result;
 	}
 
+	private static Object js_flatMap(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+		Object callbackArg = args.length > 0 ? args[0] : Undefined.INSTANCE;
+		if (!(callbackArg instanceof Function f) || callbackArg instanceof NativeRegExp) {
+			throw ScriptRuntime.notFunctionError(cx, callbackArg);
+		}
+
+		Scriptable parent = getTopLevelScope(f);
+		Scriptable thisArg;
+		if (args.length < 2 || args[1] == null || args[1] == Undefined.INSTANCE) {
+			thisArg = parent;
+		} else {
+			thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
+		}
+
+		long length = getLengthProperty(cx, o, false);
+
+		Scriptable result = cx.newArray(scope, 0);
+		long j = 0;
+		for (long i = 0; i < length; i++) {
+			Object elem = getRawElem(o, i, cx);
+			if (elem == NOT_FOUND) {
+				continue;
+			}
+			Object[] innerArgs = {elem, i, o};
+			Object mapCall = f.call(cx, parent, thisArg, innerArgs);
+			if (js_isArray(mapCall)) {
+				Scriptable arr = (Scriptable) mapCall;
+				long arrLength = getLengthProperty(cx, arr, false);
+				for (long k = 0; k < arrLength; k++) {
+					Object temp = getRawElem(arr, k, cx);
+					defineElem(cx, result, j++, temp);
+				}
+			} else {
+				defineElem(cx, result, j++, mapCall);
+			}
+		}
+		setLengthProperty(cx, result, j);
+		return result;
+	}
+
 	/**
 	 * Implements the methods "every", "filter", "forEach", "map", and "some".
 	 */
@@ -1695,6 +1737,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				arity = 0;
 				s = "flat";
 			}
+			case Id_flatMap -> {
+				arity = 1;
+				s = "flatMap";
+			}
 			default -> throw new IllegalArgumentException(String.valueOf(id));
 		}
 
@@ -1825,6 +1871,9 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 
 				case Id_flat:
 					return js_flat(cx, scope, thisObj, args);
+
+				case Id_flatMap:
+					return js_flatMap(cx, scope, thisObj, args);
 
 				case Id_every:
 				case Id_filter:
@@ -2421,6 +2470,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			case "copyWithin" -> Id_copyWithin;
 			case "at" -> Id_at;
 			case "flat" -> Id_flat;
+			case "flatMap" -> Id_flatMap;
 			default -> 0;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -74,7 +74,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int Id_includes = 30;
 	private static final int Id_copyWithin = 31;
 	private static final int SymbolId_iterator = 32;
-	private static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
+	private static final int Id_at = 33;
+	private static final int MAX_PROTOTYPE_ID = Id_at;
 	private static final int ConstructorId_join = -Id_join;
 	private static final int ConstructorId_reverse = -Id_reverse;
 	private static final int ConstructorId_sort = -Id_sort;
@@ -1225,6 +1226,21 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		return thisObj;
 	}
 
+	private static Object js_at(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+		long len = getLengthProperty(cx, o, false);
+
+		long relativeIndex = 0;
+		if (args.length >= 1) {
+			relativeIndex = (long) ScriptRuntime.toInteger(cx, args[0]);
+		}
+		long k = (relativeIndex >= 0) ? relativeIndex : len + relativeIndex;
+		if ((k < 0) || (k >= len)) {
+			return Undefined.INSTANCE;
+		}
+		return getElem(cx, thisObj, k);
+	}
+
 	/**
 	 * Implements the methods "every", "filter", "forEach", "map", and "some".
 	 */
@@ -1633,6 +1649,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				arity = 2;
 				s = "copyWithin";
 			}
+			case Id_at -> {
+				arity = 1;
+				s = "at";
+			}
 			default -> throw new IllegalArgumentException(String.valueOf(id));
 		}
 
@@ -1757,6 +1777,9 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 
 				case Id_copyWithin:
 					return js_copyWithin(cx, scope, thisObj, args);
+
+				case Id_at:
+					return js_at(cx, scope, thisObj, args);
 
 				case Id_every:
 				case Id_filter:
@@ -2351,6 +2374,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			case "entries" -> Id_entries;
 			case "includes" -> Id_includes;
 			case "copyWithin" -> Id_copyWithin;
+			case "at" -> Id_at;
 			default -> 0;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -79,7 +79,9 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int Id_at = 33;
 	private static final int Id_flat = 34;
 	private static final int Id_flatMap = 35;
-	private static final int MAX_PROTOTYPE_ID = Id_flatMap;
+	private static final int Id_findLast = 36;
+	private static final int Id_findLastIndex = 37;
+	private static final int MAX_PROTOTYPE_ID = Id_findLastIndex;
 	private static final int ConstructorId_join = -Id_join;
 	private static final int ConstructorId_reverse = -Id_reverse;
 	private static final int ConstructorId_sort = -Id_sort;
@@ -101,6 +103,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int ConstructorId_findIndex = -Id_findIndex;
 	private static final int ConstructorId_reduce = -Id_reduce;
 	private static final int ConstructorId_reduceRight = -Id_reduceRight;
+	private static final int ConstructorId_findLast = -Id_findLast;
+	private static final int ConstructorId_findLastIndex = -Id_findLastIndex;
 	private static final int ConstructorId_isArray = -26;
 	private static final int ConstructorId_of = -27;
 	private static final int ConstructorId_from = -28;
@@ -1230,9 +1234,6 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		return result;
 	}
 
-	/**
-	 * Implements the methods "every", "filter", "forEach", "map", and "some".
-	 */
 	private static boolean js_isArray(Object o) {
 		return o instanceof NativeJavaList || o instanceof List || o instanceof Scriptable s && "Array".equals(s.getClassName());
 	}
@@ -1364,6 +1365,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_some, "some", 1, cx);
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_find, "find", 1, cx);
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex, "findIndex", 1, cx);
+		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findLast, "findLast", 1, cx);
+		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findLastIndex, "findLastIndex", 1, cx);
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce, "reduce", 1, cx);
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight, "reduceRight", 1, cx);
 		addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray, "isArray", 1, cx);
@@ -1518,6 +1521,14 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				arity = 1;
 				s = "flatMap";
 			}
+			case Id_findLast -> {
+				arity = 1;
+				s = "findLast";
+			}
+			case Id_findLastIndex -> {
+				arity = 1;
+				s = "findLastIndex";
+			}
 			default -> throw new IllegalArgumentException(String.valueOf(id));
 		}
 
@@ -1553,7 +1564,9 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				case ConstructorId_find:
 				case ConstructorId_findIndex:
 				case ConstructorId_reduce:
-				case ConstructorId_reduceRight: {
+				case ConstructorId_reduceRight:
+				case ConstructorId_findLast:
+				case ConstructorId_findLastIndex: {
 					// this is a small trick; we will handle all the ConstructorId_xxx calls
 					// the same way the object calls are processed
 					// so we adjust the args, inverting the id and
@@ -1666,6 +1679,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND, scope, thisObj, args);
 				case Id_findIndex:
 					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND_INDEX, scope, thisObj, args);
+				case Id_findLast:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND_LAST, scope, thisObj, args);
+				case Id_findLastIndex:
+					return ArrayLikeAbstractOperations.iterativeMethod(cx, f, IterativeOperation.FIND_LAST_INDEX, scope, thisObj, args);
 				case Id_reduce:
 					return ArrayLikeAbstractOperations.reduceMethod(cx, ReduceOperation.REDUCE, scope, thisObj, args);
 				case Id_reduceRight:
@@ -2255,6 +2272,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			case "at" -> Id_at;
 			case "flat" -> Id_flat;
 			case "flatMap" -> Id_flatMap;
+			case "findLast" -> Id_findLast;
+			case "findLastIndex" -> Id_findLastIndex;
 			default -> 0;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeArray.java
@@ -75,7 +75,8 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 	private static final int Id_copyWithin = 31;
 	private static final int SymbolId_iterator = 32;
 	private static final int Id_at = 33;
-	private static final int MAX_PROTOTYPE_ID = Id_at;
+	private static final int Id_flat = 34;
+	private static final int MAX_PROTOTYPE_ID = Id_flat;
 	private static final int ConstructorId_join = -Id_join;
 	private static final int ConstructorId_reverse = -Id_reverse;
 	private static final int ConstructorId_sort = -Id_sort;
@@ -1241,6 +1242,43 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 		return getElem(cx, thisObj, k);
 	}
 
+	private static Object js_flat(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+		double depth;
+		if (args.length < 1 || Undefined.isUndefined(args[0])) {
+			depth = 1;
+		} else {
+			depth = ScriptRuntime.toInteger(cx, args[0]);
+		}
+
+		return flat(cx, scope, o, depth);
+	}
+
+	private static Scriptable flat(Context cx, Scriptable scope, Scriptable source, double depth) {
+		long length = getLengthProperty(cx, source, false);
+
+		Scriptable result = cx.newArray(scope, 0);
+		long j = 0;
+		for (long i = 0; i < length; i++) {
+			Object elem = getRawElem(source, i, cx);
+			if (elem == NOT_FOUND) {
+				continue;
+			}
+			if (depth >= 1 && js_isArray(elem)) {
+				Scriptable arr = flat(cx, scope, (Scriptable) elem, depth - 1);
+				long arrLength = getLengthProperty(cx, arr, false);
+				for (long k = 0; k < arrLength; k++) {
+					Object temp = getRawElem(arr, k, cx);
+					defineElem(cx, result, j++, temp);
+				}
+			} else {
+				defineElem(cx, result, j++, elem);
+			}
+		}
+		setLengthProperty(cx, result, j);
+		return result;
+	}
+
 	/**
 	 * Implements the methods "every", "filter", "forEach", "map", and "some".
 	 */
@@ -1653,6 +1691,10 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 				arity = 1;
 				s = "at";
 			}
+			case Id_flat -> {
+				arity = 0;
+				s = "flat";
+			}
 			default -> throw new IllegalArgumentException(String.valueOf(id));
 		}
 
@@ -1780,6 +1822,9 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 
 				case Id_at:
 					return js_at(cx, scope, thisObj, args);
+
+				case Id_flat:
+					return js_flat(cx, scope, thisObj, args);
 
 				case Id_every:
 				case Id_filter:
@@ -2375,6 +2420,7 @@ public class NativeArray extends IdScriptableObject implements List, DataObject 
 			case "includes" -> Id_includes;
 			case "copyWithin" -> Id_copyWithin;
 			case "at" -> Id_at;
+			case "flat" -> Id_flat;
 			default -> 0;
 		};
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeError.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeError.java
@@ -109,10 +109,18 @@ final class NativeError extends IdScriptableObject {
 				putProperty(obj, "message", ScriptRuntime.toString(cx, args[0]), cx);
 			}
 			if (arglen >= 2) {
-				putProperty(obj, "fileName", args[1], cx);
-				if (arglen >= 3) {
-					int line = ScriptRuntime.toInt32(cx, args[2]);
-					putProperty(obj, "lineNumber", line, cx);
+				if (args[1] instanceof NativeObject options) {
+					Object cause = getProperty(options, "cause", cx);
+					if (cause != NOT_FOUND) {
+						putProperty(obj, "cause", cause, cx);
+						obj.setAttributes(cx, "cause", DONTENUM);
+					}
+				} else {
+					putProperty(obj, "fileName", ScriptRuntime.toString(cx, args[1]), cx);
+					if (arglen >= 3) {
+						int line = ScriptRuntime.toInt32(cx, args[2]);
+						putProperty(obj, "lineNumber", line, cx);
+					}
 				}
 			}
 		}

--- a/src/main/java/dev/latvian/mods/rhino/NativeError.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeError.java
@@ -25,6 +25,7 @@ final class NativeError extends IdScriptableObject {
 	private static final int Id_toString = 2;
 	private static final int Id_toSource = 3;
 	private static final int ConstructorId_captureStackTrace = -1;
+	private static final int ConstructorId_isError = -2;
 	private static final int MAX_PROTOTYPE_ID = 3;
 
 	/**
@@ -185,6 +186,7 @@ final class NativeError extends IdScriptableObject {
 	@Override
 	protected void fillConstructorProperties(IdFunctionObject ctor, Context cx) {
 		addIdFunctionProperty(ctor, ERROR_TAG, ConstructorId_captureStackTrace, "captureStackTrace", 2, cx);
+		addIdFunctionProperty(ctor, ERROR_TAG, ConstructorId_isError, "isError", 1, cx);
 
 		// This is running on the global "Error" object. Associate an object there that can store
 		// default stack trace, etc.
@@ -252,6 +254,9 @@ final class NativeError extends IdScriptableObject {
 			case ConstructorId_captureStackTrace:
 				js_captureStackTrace(cx, thisObj, args);
 				return Undefined.INSTANCE;
+
+			case ConstructorId_isError:
+				return js_isError(args);
 		}
 		throw new IllegalArgumentException(String.valueOf(id));
 	}
@@ -320,6 +325,11 @@ final class NativeError extends IdScriptableObject {
 
 		Scriptable eltArray = cx.newArray(this, elts);
 		return prepare.call(cx, prepare, this, new Object[]{this, eltArray});
+	}
+
+	private static Boolean js_isError(Object[] args) {
+		Object arg = args.length > 0 ? args[0] : Undefined.INSTANCE;
+		return arg instanceof NativeError;
 	}
 
 	// #/string_id_map#

--- a/src/main/java/dev/latvian/mods/rhino/NativeFunction.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeFunction.java
@@ -19,6 +19,7 @@ public abstract class NativeFunction extends BaseFunction {
 
 	public final void initScriptFunction(Context cx, Scriptable scope, boolean es6GeneratorFunction) {
 		ScriptRuntime.setFunctionProtoAndParent(cx, scope, this, es6GeneratorFunction);
+		setStandardPropertyAttributes(READONLY | DONTENUM);
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaArray.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaArray.java
@@ -10,6 +10,7 @@ import dev.latvian.mods.rhino.type.TypeInfo;
 import dev.latvian.mods.rhino.util.DefaultValueTypeHint;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 
 /**
  * This class reflects Java arrays into the JavaScript environment.
@@ -146,5 +147,15 @@ public class NativeJavaArray extends NativeJavaObject implements SymbolScriptabl
 			prototype = ScriptableObject.getArrayPrototype(this.getParentScope(), cx);
 		}
 		return prototype;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return (obj instanceof NativeJavaArray other) && Objects.equals(other.array, array);
+	}
+
+	@Override
+	public int hashCode() {
+		return array == null ? 0 : array.hashCode();
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/NativeJavaObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeJavaObject.java
@@ -17,6 +17,7 @@ import dev.latvian.mods.rhino.util.JavaIteratorWrapper;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class reflects non-Array Java objects into the JavaScript environment.  It
@@ -332,5 +333,15 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper {
 			}
 		}
 		return value;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj != null && obj.getClass().equals(getClass()) && Objects.equals(((NativeJavaObject) obj).javaObject, javaObject);
+	}
+
+	@Override
+	public int hashCode() {
+		return javaObject == null ? 0 : javaObject.hashCode();
 	}
 }

--- a/src/main/java/dev/latvian/mods/rhino/NativeMap.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeMap.java
@@ -6,12 +6,16 @@
 
 package dev.latvian.mods.rhino;
 
+import java.util.List;
+import java.util.Map;
+
 public class NativeMap extends IdScriptableObject {
 	static final String ITERATOR_TAG = "Map Iterator";
 	private static final Object MAP_TAG = "Map";
 	private static final Object NULL_VALUE = new Object();
 	// Note that "SymbolId_iterator" is not present here. That's because the spec
 	// requires that it be the same value as the "entries" prototype property.
+	private static final int ConstructorId_groupBy = -1;
 	private static final int Id_constructor = 1;
 	private static final int Id_set = 2;
 	private static final int Id_get = 3;
@@ -113,6 +117,12 @@ public class NativeMap extends IdScriptableObject {
 	}
 
 	@Override
+	protected void fillConstructorProperties(IdFunctionObject ctor, Context cx) {
+		addIdFunctionProperty(ctor, MAP_TAG, ConstructorId_groupBy, "groupBy", 2, cx);
+		super.fillConstructorProperties(ctor, cx);
+	}
+
+	@Override
 	public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
 		if (!f.hasTag(MAP_TAG)) {
 			return super.execIdCall(f, cx, scope, thisObj, args);
@@ -149,6 +159,22 @@ public class NativeMap extends IdScriptableObject {
 				return realThis(thisObj, f, cx).js_forEach(cx, scope, args.length > 0 ? args[0] : Undefined.INSTANCE, args.length > 1 ? args[1] : Undefined.INSTANCE);
 			case SymbolId_getSize:
 				return realThis(thisObj, f, cx).js_getSize();
+
+			case ConstructorId_groupBy: {
+				Object items = args.length < 1 ? Undefined.INSTANCE : args[0];
+				Object callback = args.length < 2 ? Undefined.INSTANCE : args[1];
+
+				Map<Object, List<Object>> groups = AbstractEcmaObjectOperations.groupBy(cx, scope, f, items, callback, AbstractEcmaObjectOperations.KEY_COERCION.COLLECTION);
+
+				NativeMap map = (NativeMap) cx.newObject(scope, "Map");
+
+				for (Map.Entry<Object, List<Object>> entry : groups.entrySet()) {
+					Scriptable elements = cx.newArray(scope, entry.getValue().toArray());
+					map.entries.put(cx, entry.getKey(), elements);
+				}
+
+				return map;
+			}
 		}
 		throw new IllegalArgumentException("Map.prototype has no method: " + f.getFunctionName());
 	}

--- a/src/main/java/dev/latvian/mods/rhino/NativeMath.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeMath.java
@@ -55,7 +55,8 @@ final class NativeMath extends IdScriptableObject {
 	private static final int Id_log2 = 34;
 	private static final int Id_fround = 35;
 	private static final int Id_clz32 = 36;
-	private static final int LAST_METHOD_ID = Id_clz32;
+	private static final int Id_f16round = 37;
+	private static final int LAST_METHOD_ID = Id_f16round;
 	private static final int Id_E = LAST_METHOD_ID + 1;
 	private static final int Id_PI = LAST_METHOD_ID + 2;
 	private static final int Id_LN10 = LAST_METHOD_ID + 3;
@@ -169,6 +170,148 @@ final class NativeMath extends IdScriptableObject {
 		return Math.sqrt(y);
 	}
 
+	private static double js_f16round(double x) {
+		// Handle special cases
+		if (Double.isNaN(x)) {
+			return Double.NaN;
+		}
+		if (x == 0.0) {
+			return x; // Preserve sign of zero
+		}
+		if (Double.isInfinite(x)) {
+			return x;
+		}
+
+		// Extract components from double precision
+		long bits = Double.doubleToLongBits(x);
+		int sign = (int) (bits >>> 63);
+		int exponent = (int) ((bits >>> 52) & 0x7FF);
+		long mantissa = bits & 0x000FFFFFFFFFFFFFL;
+
+		// Adjust from double bias (1023) to float16 bias (15)
+		exponent = exponent - 1023 + 15;
+
+		// Handle overflow to infinity
+		if (exponent >= 31) {
+			return (sign != 0) ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+		}
+
+		// Handle underflow and subnormal values
+		if (exponent < 0) {
+			return handleSubnormalF16(sign, exponent, mantissa);
+		}
+
+		// Normal value: round mantissa from 52 to 10 bits
+		return handleNormalF16(sign, exponent, mantissa);
+	}
+
+	private static double handleSubnormalF16(int sign, int exponent, long mantissa) {
+		// Values below 2^-24 underflow to zero
+		if (exponent < -10) {
+			return (sign != 0) ? -0.0 : 0.0;
+		}
+
+		// Special case: exactly 2^-25 rounds to zero (ties-to-even)
+		if (exponent == -10 && mantissa == 0) {
+			return (sign != 0) ? -0.0 : 0.0;
+		}
+
+		// Special case: slightly above 2^-25 rounds to 2^-24
+		if (exponent == -10 && mantissa > 0) {
+			double smallestSubnormal = 5.960464477539063e-8; // 2^-24
+			return (sign != 0) ? -smallestSubnormal : smallestSubnormal;
+		}
+
+		// Convert to subnormal representation
+		int totalShift = 42 + (1 - exponent);
+		mantissa = mantissa | (1L << 52); // Add implicit 1 bit
+
+		// Extract rounding information before shift
+		long roundBit = (mantissa >> (totalShift - 1)) & 1;
+		long stickyBits = mantissa & ((1L << (totalShift - 1)) - 1);
+
+		// Shift to get 10-bit mantissa
+		mantissa >>>= totalShift;
+
+		// Apply ties-to-even rounding
+		if (roundBit == 1 && (stickyBits != 0 || (mantissa & 1) == 1)) {
+			mantissa++;
+		}
+
+		// Reconstruct subnormal value
+		if (mantissa == 0) {
+			return (sign != 0) ? -0.0 : 0.0;
+		}
+
+		// Check for overflow to normal range
+		if (mantissa >= (1L << 10)) {
+			// Smallest normal = 2^-14
+			return (sign != 0) ? -6.103515625e-5 : 6.103515625e-5;
+		}
+
+		// Subnormal value = 2^-14 * (mantissa / 1024)
+		double value = Math.scalb((double) mantissa / 1024.0, -14);
+		return (sign != 0) ? -value : value;
+	}
+
+	private static double handleNormalF16(int sign, int exponent, long mantissa) {
+		// Add implicit 1 bit for normal values
+		long fullMantissa = mantissa | (1L << 52);
+
+		// Extract rounding information
+		long roundBit = (fullMantissa >> 41) & 1;
+		long stickyBits = fullMantissa & ((1L << 41) - 1);
+		fullMantissa >>>= 42;
+
+		// Handle boundary between largest subnormal and smallest normal
+		if (exponent == 0) {
+			if (fullMantissa == 2046) {
+				// Exactly the largest subnormal
+				return reconstructSubnormalF16(sign, 1023);
+			} else if (fullMantissa == 2047 && roundBit == 0 && stickyBits == 0) {
+				// Midpoint: ties-to-even rounds to smallest normal
+				return reconstructNormalF16(sign, 1, 0);
+			}
+		}
+
+		// Extract 10-bit mantissa (remove implicit 1)
+		mantissa = fullMantissa & 0x3FF;
+
+		// Apply ties-to-even rounding
+		if (roundBit == 1 && (stickyBits != 0 || (mantissa & 1) == 1)) {
+			mantissa++;
+		}
+
+		// Handle mantissa overflow
+		if (mantissa >= (1L << 10)) {
+			mantissa = 0;
+			exponent++;
+			if (exponent >= 31) {
+				return (sign != 0) ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+			}
+		}
+
+		// Reconstruct the value
+		if (exponent == 0) {
+			return reconstructSubnormalF16(sign, mantissa);
+		} else {
+			return reconstructNormalF16(sign, exponent, mantissa);
+		}
+	}
+
+	private static double reconstructSubnormalF16(int sign, long mantissa) {
+		if (mantissa == 0) {
+			return (sign != 0) ? -0.0 : 0.0;
+		}
+		double value = Math.scalb((double) mantissa / 1024.0, -14);
+		return (sign != 0) ? -value : value;
+	}
+
+	private static double reconstructNormalF16(int sign, int exponent, long mantissa) {
+		long resultBits = ((long) sign << 63) | (((long) (exponent + 1023 - 15)) << 52) | (mantissa << 42);
+		return Double.longBitsToDouble(resultBits);
+	}
+
 	private static double js_trunc(double d) {
 		return ((d < 0.0) ? Math.ceil(d) : Math.floor(d));
 	}
@@ -261,6 +404,10 @@ final class NativeMath extends IdScriptableObject {
 				case Id_expm1 -> {
 					arity = 1;
 					name = "expm1";
+				}
+				case Id_f16round -> {
+					arity = 1;
+					name = "f16round";
 				}
 				case Id_floor -> {
 					arity = 1;
@@ -505,6 +652,11 @@ final class NativeMath extends IdScriptableObject {
 				x = Math.expm1(x);
 				break;
 
+			case Id_f16round:
+				x = ScriptRuntime.toNumber(cx, args, 0);
+				x = js_f16round(x);
+				break;
+
 			case Id_floor:
 				x = ScriptRuntime.toNumber(cx, args, 0);
 				x = Math.floor(x);
@@ -671,6 +823,7 @@ final class NativeMath extends IdScriptableObject {
 			case "log2" -> Id_log2;
 			case "fround" -> Id_fround;
 			case "clz32" -> Id_clz32;
+			case "f16round" -> Id_f16round;
 			case "E" -> Id_E;
 			case "PI" -> Id_PI;
 			case "LN10" -> Id_LN10;

--- a/src/main/java/dev/latvian/mods/rhino/NativeNumber.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeNumber.java
@@ -23,6 +23,7 @@ final class NativeNumber extends IdScriptableObject {
 
 	private static final int MAX_PRECISION = 100;
 	private static final double MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
+	private static final double EPSILON = 2.220446049250313e-16; // Math.pow(2, -52)
 	private static final int ConstructorId_isFinite = -1;
 	private static final int ConstructorId_isNaN = -2;
 	private static final int ConstructorId_isInteger = -3;
@@ -183,6 +184,7 @@ final class NativeNumber extends IdScriptableObject {
 		ctor.defineProperty(cx, "MIN_VALUE", ScriptRuntime.wrapNumber(Double.MIN_VALUE), attr);
 		ctor.defineProperty(cx, "MAX_SAFE_INTEGER", ScriptRuntime.wrapNumber(MAX_SAFE_INTEGER), attr);
 		ctor.defineProperty(cx, "MIN_SAFE_INTEGER", ScriptRuntime.wrapNumber(MIN_SAFE_INTEGER), attr);
+		ctor.defineProperty(cx, "EPSILON", ScriptRuntime.wrapNumber(EPSILON), attr);
 
 		addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isFinite, "isFinite", 1, cx);
 		addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isNaN, "isNaN", 1, cx);

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -60,6 +60,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 	private static final int ConstructorId_setPrototypeOf = -17;
 	private static final int ConstructorId_entries = -18;
 	private static final int ConstructorId_values = -19;
+	private static final int ConstructorId_fromEntries = -20;
 	private static final int Id_constructor = 1;
 	private static final int Id_toString = 2;
 	private static final int Id_toLocaleString = 3;
@@ -127,6 +128,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_keys, "keys", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_entries, "entries", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_values, "values", 1, cx);
+		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_fromEntries, "fromEntries", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames, "getOwnPropertyNames", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols, "getOwnPropertySymbols", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyDescriptor, "getOwnPropertyDescriptor", 2, cx);
@@ -421,12 +423,48 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				Object[] ids = obj.getIds(cx);
 				Object[] entries = new Object[ids.length];
 				for (int i = 0; i < ids.length; i++) {
-					Object[] entry = new Object[2];
-					entry[0] = ScriptRuntime.toString(cx, ids[i]);
-					entry[1] = getValueForId(cx, obj, ids[i]);
-					entries[i] = cx.newArray(scope, entry);
+					if (ids[i] instanceof Integer key) {
+						entries[i] = cx.newArray(scope, new Object[]{ ids[i], obj.get(cx, key, scope) });
+					} else {
+						String key = ScriptRuntime.toString(cx, ids[i]);
+						entries[i] = cx.newArray(scope, new Object[]{ ids[i], obj.get(cx, key, scope) });
+					}
 				}
 				return cx.newArray(scope, entries);
+			}
+			case ConstructorId_fromEntries: {
+				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
+				Scriptable iterable = getCompatibleObject(cx, scope, arg);
+				Scriptable obj = cx.newObject(scope);
+				Object ito = ScriptRuntime.callIterator(cx, scope, iterable);
+				if (!Undefined.INSTANCE.equals(ito)) {
+					try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, ito)) {
+						for (Object val : it) {
+							if (!(val instanceof Scriptable entry) || val instanceof Symbol) {
+								throw ScriptRuntime.typeError1(cx, "msg.arg.not.object", ScriptRuntime.typeof(cx, val));
+							}
+							Object key = entry.get(cx, 0, entry);
+							if (key == NOT_FOUND) {
+								key = Undefined.INSTANCE;
+							}
+							Object value = entry.get(cx, 1, entry);
+							if (value == NOT_FOUND) {
+								value = Undefined.INSTANCE;
+							}
+							if (key instanceof Symbol sym && obj instanceof SymbolScriptable symObj) {
+								symObj.put(cx, sym, obj, value);
+							} else {
+								ScriptRuntime.StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, key);
+								if (s.stringId == null) {
+									obj.put(cx, s.index, obj, value);
+								} else {
+									obj.put(cx, s.stringId, obj, value);
+								}
+							}
+						}
+					}
+				}
+				return obj;
 			}
 			case ConstructorId_values: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -63,6 +63,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 	private static final int ConstructorId_fromEntries = -20;
 	private static final int ConstructorId_hasOwn = -21;
 	private static final int ConstructorId_getOwnPropertyDescriptors = -22;
+	private static final int ConstructorId_groupBy = -23;
 	private static final int Id_constructor = 1;
 	private static final int Id_toString = 2;
 	private static final int Id_toLocaleString = 3;
@@ -147,6 +148,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_freeze, "freeze", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_assign, "assign", 2, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_is, "is", 2, cx);
+		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_groupBy, "groupBy", 2, cx);
 		super.fillConstructorProperties(ctor, cx);
 	}
 
@@ -653,6 +655,28 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				return ScriptRuntime.same(cx, a1, a2);
 			}
 
+			case ConstructorId_groupBy: {
+				Object items = args.length < 1 ? Undefined.INSTANCE : args[0];
+				Object callback = args.length < 2 ? Undefined.INSTANCE : args[1];
+
+				Map<Object, List<Object>> groups = AbstractEcmaObjectOperations.groupBy(cx, scope, f, items, callback, AbstractEcmaObjectOperations.KEY_COERCION.PROPERTY);
+
+				NativeObject obj = (NativeObject) cx.newObject(scope);
+				obj.setPrototype(null);
+
+				for (Map.Entry<Object, List<Object>> entry : groups.entrySet()) {
+					Scriptable elements = cx.newArray(scope, entry.getValue().toArray());
+
+					ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
+					desc.put(cx, "enumerable", desc, Boolean.TRUE);
+					desc.put(cx, "configurable", desc, Boolean.TRUE);
+					desc.put(cx, "value", desc, elements);
+
+					obj.defineOwnProperty(cx, entry.getKey(), desc);
+				}
+
+				return obj;
+			}
 
 			default:
 				throw new IllegalArgumentException(String.valueOf(id));

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -567,20 +567,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 					return Boolean.TRUE;
 				}
 
-				ScriptableObject obj = ensureScriptableObject(arg, cx);
-
-				if (obj.isExtensible()) {
-					return Boolean.FALSE;
-				}
-
-				for (Object name : obj.getAllIds(cx)) {
-					Object configurable = obj.getOwnPropertyDescriptor(cx, name).get(cx, "configurable");
-					if (Boolean.TRUE.equals(configurable)) {
-						return Boolean.FALSE;
-					}
-				}
-
-				return Boolean.TRUE;
+				return AbstractEcmaObjectOperations.testIntegrityLevel(cx, arg, AbstractEcmaObjectOperations.INTEGRITY_LEVEL.SEALED);
 			}
 			case ConstructorId_isFrozen: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
@@ -588,23 +575,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 					return Boolean.TRUE;
 				}
 
-				ScriptableObject obj = ensureScriptableObject(arg, cx);
-
-				if (obj.isExtensible()) {
-					return Boolean.FALSE;
-				}
-
-				for (Object name : obj.getAllIds(cx)) {
-					ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-					if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
-						return Boolean.FALSE;
-					}
-					if (isDataDescriptor(desc, cx) && Boolean.TRUE.equals(desc.get(cx, "writable"))) {
-						return Boolean.FALSE;
-					}
-				}
-
-				return Boolean.TRUE;
+				return AbstractEcmaObjectOperations.testIntegrityLevel(cx, arg, AbstractEcmaObjectOperations.INTEGRITY_LEVEL.FROZEN);
 			}
 			case ConstructorId_seal: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
@@ -612,18 +583,9 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 					return arg;
 				}
 
-				ScriptableObject obj = ensureScriptableObject(arg, cx);
+				AbstractEcmaObjectOperations.setIntegrityLevel(cx, arg, AbstractEcmaObjectOperations.INTEGRITY_LEVEL.SEALED);
 
-				for (Object name : obj.getAllIds(cx)) {
-					ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-					if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
-						desc.put(cx, "configurable", desc, Boolean.FALSE);
-						obj.defineOwnProperty(cx, name, desc, false);
-					}
-				}
-				obj.preventExtensions();
-
-				return obj;
+				return arg;
 			}
 			case ConstructorId_freeze: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
@@ -631,21 +593,9 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 					return arg;
 				}
 
-				ScriptableObject obj = ensureScriptableObject(arg, cx);
+				AbstractEcmaObjectOperations.setIntegrityLevel(cx, arg, AbstractEcmaObjectOperations.INTEGRITY_LEVEL.FROZEN);
 
-				for (Object name : obj.getIds(cx, true, true)) {
-					ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-					if (isDataDescriptor(desc, cx) && Boolean.TRUE.equals(desc.get(cx, "writable"))) {
-						desc.put(cx, "writable", desc, Boolean.FALSE);
-					}
-					if (Boolean.TRUE.equals(desc.get(cx, "configurable"))) {
-						desc.put(cx, "configurable", desc, Boolean.FALSE);
-					}
-					obj.defineOwnProperty(cx, name, desc, false);
-				}
-				obj.preventExtensions();
-
-				return obj;
+				return arg;
 			}
 
 			case ConstructorId_assign: {

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -62,6 +62,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 	private static final int ConstructorId_values = -19;
 	private static final int ConstructorId_fromEntries = -20;
 	private static final int ConstructorId_hasOwn = -21;
+	private static final int ConstructorId_getOwnPropertyDescriptors = -22;
 	private static final int Id_constructor = 1;
 	private static final int Id_toString = 2;
 	private static final int Id_toLocaleString = 3;
@@ -134,6 +135,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames, "getOwnPropertyNames", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols, "getOwnPropertySymbols", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyDescriptor, "getOwnPropertyDescriptor", 2, cx);
+		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyDescriptors, "getOwnPropertyDescriptors", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_defineProperty, "defineProperty", 3, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isExtensible, "isExtensible", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_preventExtensions, "preventExtensions", 1, cx);
@@ -496,6 +498,26 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
 				Object propertyName = args.length < 2 ? Undefined.INSTANCE : args[1];
 				return AbstractEcmaObjectOperations.hasOwnProperty(cx, arg, propertyName);
+			}
+			case ConstructorId_getOwnPropertyDescriptors: {
+				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
+				Scriptable s = getCompatibleObject(cx, scope, arg);
+				ScriptableObject obj = ensureScriptableObject(s, cx);
+
+				ScriptableObject descs = (ScriptableObject) cx.newObject(scope);
+				for (Object key : obj.getIds(cx, true, true)) {
+					Scriptable desc = obj.getOwnPropertyDescriptor(cx, key);
+					if (desc == null) {
+						continue;
+					} else if (key instanceof Symbol sym) {
+						descs.put(cx, sym, descs, desc);
+					} else if (key instanceof Integer index) {
+						descs.put(cx, index, descs, desc);
+					} else {
+						descs.put(cx, ScriptRuntime.toString(cx, key), descs, desc);
+					}
+				}
+				return descs;
 			}
 			case ConstructorId_getOwnPropertyDescriptor: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];

--- a/src/main/java/dev/latvian/mods/rhino/NativeObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeObject.java
@@ -61,6 +61,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 	private static final int ConstructorId_entries = -18;
 	private static final int ConstructorId_values = -19;
 	private static final int ConstructorId_fromEntries = -20;
+	private static final int ConstructorId_hasOwn = -21;
 	private static final int Id_constructor = 1;
 	private static final int Id_toString = 2;
 	private static final int Id_toLocaleString = 3;
@@ -129,6 +130,7 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_entries, "entries", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_values, "values", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_fromEntries, "fromEntries", 1, cx);
+		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_hasOwn, "hasOwn", 2, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames, "getOwnPropertyNames", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols, "getOwnPropertySymbols", 1, cx);
 		addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyDescriptor, "getOwnPropertyDescriptor", 2, cx);
@@ -244,19 +246,10 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 				if (thisObj == null || Undefined.isUndefined(thisObj)) {
 					throw ScriptRuntime.typeError0(cx, "msg." + (thisObj == null ? "null" : "undef") + ".to.object");
 				}
-				boolean result;
+
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
-				if (arg instanceof Symbol) {
-					result = ensureSymbolScriptable(thisObj, cx).has(cx, (Symbol) arg, thisObj);
-				} else {
-					ScriptRuntime.StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, arg);
-					if (s.stringId == null) {
-						result = thisObj.has(cx, s.index, thisObj);
-					} else {
-						result = thisObj.has(cx, s.stringId, thisObj);
-					}
-				}
-				return result;
+
+				return AbstractEcmaObjectOperations.hasOwnProperty(cx, thisObj, arg);
 			}
 
 			case Id_propertyIsEnumerable: {
@@ -498,6 +491,11 @@ public class NativeObject extends IdScriptableObject implements Map, DataObject 
 					}
 				}
 				return cx.newArray(scope, syms.toArray());
+			}
+			case ConstructorId_hasOwn: {
+				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];
+				Object propertyName = args.length < 2 ? Undefined.INSTANCE : args[1];
+				return AbstractEcmaObjectOperations.hasOwnProperty(cx, arg, propertyName);
 			}
 			case ConstructorId_getOwnPropertyDescriptor: {
 				Object arg = args.length < 1 ? Undefined.INSTANCE : args[0];

--- a/src/main/java/dev/latvian/mods/rhino/NativeString.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeString.java
@@ -11,7 +11,9 @@ import dev.latvian.mods.rhino.regexp.RegExp;
 
 import java.text.Collator;
 import java.text.Normalizer;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * This class implements the String native object.
@@ -89,7 +91,9 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 	private static final int SymbolId_iterator = 50;
 	private static final int Id_replaceAll = 51;
 	private static final int Id_at = 52;
-	private static final int MAX_PROTOTYPE_ID = Id_at;
+	private static final int Id_isWellFormed = 53;
+	private static final int Id_toWellFormed = 54;
+	private static final int MAX_PROTOTYPE_ID = Id_toWellFormed;
 	private static final int ConstructorId_charAt = -Id_charAt;
 	private static final int ConstructorId_charCodeAt = -Id_charCodeAt;
 	private static final int ConstructorId_indexOf = -Id_indexOf;
@@ -687,6 +691,14 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 				arity = 1;
 				s = "at";
 			}
+			case Id_isWellFormed -> {
+				arity = 0;
+				s = "isWellFormed";
+			}
+			case Id_toWellFormed -> {
+				arity = 0;
+				s = "toWellFormed";
+			}
 			case Id_localeCompare -> {
 				arity = 1;
 				s = "localeCompare";
@@ -1021,6 +1033,73 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 
 					return str.substring(k, k + 1);
 				}
+
+				case Id_isWellFormed: {
+					CharSequence str = ScriptRuntime.toCharSequence(cx, ScriptRuntimeES6.requireObjectCoercible(cx, thisObj, f));
+					int len = str.length();
+					boolean foundLeadingSurrogate = false;
+					for (int i = 0; i < len; i++) {
+						char c = str.charAt(i);
+						if (Character.isHighSurrogate(c)) {
+							if (foundLeadingSurrogate) {
+								return false;
+							}
+							foundLeadingSurrogate = true;
+						} else if (Character.isLowSurrogate(c)) {
+							if (!foundLeadingSurrogate) {
+								return false;
+							}
+							foundLeadingSurrogate = false;
+						} else if (foundLeadingSurrogate) {
+							return false;
+						}
+					}
+					return !foundLeadingSurrogate;
+				}
+
+				case Id_toWellFormed: {
+					CharSequence str = ScriptRuntime.toCharSequence(cx, ScriptRuntimeES6.requireObjectCoercible(cx, thisObj, f));
+					// true represents a surrogate pair
+					// false represents a singular surrogate
+					// normal characters aren't present
+					Map<Integer, Boolean> surrogates = new HashMap<>();
+
+					int len = str.length();
+					char prev = 0;
+					int firstSurrogateIndex = -1;
+					for (int i = 0; i < len; i++) {
+						char c = str.charAt(i);
+
+						if (Character.isHighSurrogate(prev) && Character.isLowSurrogate(c)) {
+							surrogates.put(i - 1, Boolean.TRUE);
+							surrogates.put(i, Boolean.TRUE);
+						} else if (Character.isHighSurrogate(c) || Character.isLowSurrogate(c)) {
+							surrogates.put(i, Boolean.FALSE);
+							if (firstSurrogateIndex == -1) {
+								firstSurrogateIndex = i;
+							}
+						}
+
+						prev = c;
+					}
+
+					if (surrogates.isEmpty()) {
+						return str.toString();
+					}
+
+					StringBuilder sb = new StringBuilder(str.subSequence(0, firstSurrogateIndex));
+					for (int i = firstSurrogateIndex; i < len; i++) {
+						char c = str.charAt(i);
+						Boolean pairOrNormal = surrogates.get(i);
+						if (pairOrNormal == null || pairOrNormal) {
+							sb.append(c);
+						} else {
+							sb.append('�');
+						}
+					}
+
+					return sb.toString();
+				}
 				// ECMA-262 1 5.5.4.9
 				case Id_localeCompare: {
 					// For now, create and configure a collator instance. I can't
@@ -1260,6 +1339,8 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 			case "replace" -> Id_replace;
 			case "replaceAll" -> Id_replaceAll;
 			case "at" -> Id_at;
+			case "isWellFormed" -> Id_isWellFormed;
+			case "toWellFormed" -> Id_toWellFormed;
 			case "localeCompare" -> Id_localeCompare;
 			case "toLocaleLowerCase" -> Id_toLocaleLowerCase;
 			case "toLocaleUpperCase" -> Id_toLocaleUpperCase;

--- a/src/main/java/dev/latvian/mods/rhino/NativeString.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeString.java
@@ -87,7 +87,8 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 	private static final int Id_trimStart = 48;
 	private static final int Id_trimEnd = 49;
 	private static final int SymbolId_iterator = 50;
-	private static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
+	private static final int Id_replaceAll = 51;
+	private static final int MAX_PROTOTYPE_ID = Id_replaceAll;
 	private static final int ConstructorId_charAt = -Id_charAt;
 	private static final int ConstructorId_charCodeAt = -Id_charCodeAt;
 	private static final int ConstructorId_indexOf = -Id_indexOf;
@@ -103,6 +104,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 	private static final int ConstructorId_match = -Id_match;
 	private static final int ConstructorId_search = -Id_search;
 	private static final int ConstructorId_replace = -Id_replace;
+	private static final int ConstructorId_replaceAll = -Id_replaceAll;
 	private static final int ConstructorId_localeCompare = -Id_localeCompare;
 	private static final int ConstructorId_toLocaleLowerCase = -Id_toLocaleLowerCase;
 
@@ -528,6 +530,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_match, "match", 2, cx);
 		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_search, "search", 2, cx);
 		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_replace, "replace", 2, cx);
+		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_replaceAll, "replaceAll", 2, cx);
 		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_localeCompare, "localeCompare", 2, cx);
 		addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_toLocaleLowerCase, "toLocaleLowerCase", 1, cx);
 		super.fillConstructorProperties(ctor, cx);
@@ -675,6 +678,10 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 				arity = 2;
 				s = "replace";
 			}
+			case Id_replaceAll -> {
+				arity = 2;
+				s = "replaceAll";
+			}
 			case Id_localeCompare -> {
 				arity = 1;
 				s = "localeCompare";
@@ -768,6 +775,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 				case ConstructorId_match:
 				case ConstructorId_search:
 				case ConstructorId_replace:
+				case ConstructorId_replaceAll:
 				case ConstructorId_localeCompare:
 				case ConstructorId_toLocaleLowerCase: {
 					if (args.length > 0) {
@@ -977,14 +985,17 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 
 				case Id_match:
 				case Id_search:
-				case Id_replace: {
+				case Id_replace:
+				case Id_replaceAll: {
 					int actionType;
 					if (id == Id_match) {
 						actionType = RegExp.RA_MATCH;
 					} else if (id == Id_search) {
 						actionType = RegExp.RA_SEARCH;
-					} else {
+					} else if (id == Id_replace) {
 						actionType = RegExp.RA_REPLACE;
+					} else {
+						actionType = RegExp.RA_REPLACE_ALL;
 					}
 
 					ScriptRuntimeES6.requireObjectCoercible(cx, thisObj, f);
@@ -1227,6 +1238,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 			case "match" -> Id_match;
 			case "search" -> Id_search;
 			case "replace" -> Id_replace;
+			case "replaceAll" -> Id_replaceAll;
 			case "localeCompare" -> Id_localeCompare;
 			case "toLocaleLowerCase" -> Id_toLocaleLowerCase;
 			case "toLocaleUpperCase" -> Id_toLocaleUpperCase;

--- a/src/main/java/dev/latvian/mods/rhino/NativeString.java
+++ b/src/main/java/dev/latvian/mods/rhino/NativeString.java
@@ -88,7 +88,8 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 	private static final int Id_trimEnd = 49;
 	private static final int SymbolId_iterator = 50;
 	private static final int Id_replaceAll = 51;
-	private static final int MAX_PROTOTYPE_ID = Id_replaceAll;
+	private static final int Id_at = 52;
+	private static final int MAX_PROTOTYPE_ID = Id_at;
 	private static final int ConstructorId_charAt = -Id_charAt;
 	private static final int ConstructorId_charCodeAt = -Id_charCodeAt;
 	private static final int ConstructorId_indexOf = -Id_indexOf;
@@ -682,6 +683,10 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 				arity = 2;
 				s = "replaceAll";
 			}
+			case Id_at -> {
+				arity = 1;
+				s = "at";
+			}
 			case Id_localeCompare -> {
 				arity = 1;
 				s = "localeCompare";
@@ -1001,6 +1006,21 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 					ScriptRuntimeES6.requireObjectCoercible(cx, thisObj, f);
 					return cx.getRegExp().action(cx, scope, thisObj, args, actionType);
 				}
+
+				case Id_at: {
+					String str = ScriptRuntime.toString(cx, ScriptRuntimeES6.requireObjectCoercible(cx, thisObj, f));
+					Object targetArg = (args.length >= 1) ? args[0] : Undefined.INSTANCE;
+					int len = str.length();
+					int relativeIndex = (int) ScriptRuntime.toInteger(cx, targetArg);
+
+					int k = (relativeIndex >= 0) ? relativeIndex : len + relativeIndex;
+
+					if ((k < 0) || (k >= len)) {
+						return Undefined.INSTANCE;
+					}
+
+					return str.substring(k, k + 1);
+				}
 				// ECMA-262 1 5.5.4.9
 				case Id_localeCompare: {
 					// For now, create and configure a collator instance. I can't
@@ -1239,6 +1259,7 @@ final class NativeString extends IdScriptableObject implements Wrapper {
 			case "search" -> Id_search;
 			case "replace" -> Id_replace;
 			case "replaceAll" -> Id_replaceAll;
+			case "at" -> Id_at;
 			case "localeCompare" -> Id_localeCompare;
 			case "toLocaleLowerCase" -> Id_toLocaleLowerCase;
 			case "toLocaleUpperCase" -> Id_toLocaleUpperCase;

--- a/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
+++ b/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
@@ -2551,7 +2551,13 @@ public class ScriptRuntime {
 		return hasObjectElem(cx, (Scriptable) b, a);
 	}
 
-	public static boolean cmp_LT(Context cx, Object val1, Object val2) {
+	/**
+	 * Implements the relational operators {@code <}, {@code <=}, {@code >} and {@code >=},
+	 * always evaluating (converting) val1 before val2 as per spec.
+	 */
+	public static boolean compare(Context cx, Object val1, Object val2, int op) {
+		assert op == Token.GE || op == Token.LE || op == Token.GT || op == Token.LT;
+
 		double d1, d2;
 		if (val1 instanceof Number && val2 instanceof Number) {
 			d1 = ((Number) val1).doubleValue();
@@ -2567,40 +2573,38 @@ public class ScriptRuntime {
 				val2 = ((Scriptable) val2).getDefaultValue(cx, DefaultValueTypeHint.NUMBER);
 			}
 			if (val1 instanceof CharSequence && val2 instanceof CharSequence) {
-				return val1.toString().compareTo(val2.toString()) < 0;
+				return switch (op) {
+					case Token.GE -> val1.toString().compareTo(val2.toString()) >= 0;
+					case Token.LE -> val1.toString().compareTo(val2.toString()) <= 0;
+					case Token.GT -> val1.toString().compareTo(val2.toString()) > 0;
+					case Token.LT -> val1.toString().compareTo(val2.toString()) < 0;
+					default -> throw Kit.codeBug();
+				};
 			}
 			d1 = toNumber(cx, val1);
 			d2 = toNumber(cx, val2);
 		}
-		return d1 < d2;
+		return switch (op) {
+			case Token.GE -> d1 >= d2;
+			case Token.LE -> d1 <= d2;
+			case Token.GT -> d1 > d2;
+			case Token.LT -> d1 < d2;
+			default -> throw Kit.codeBug();
+		};
+	}
+
+	@Deprecated
+	public static boolean cmp_LT(Context cx, Object val1, Object val2) {
+		return compare(cx, val1, val2, Token.LT);
 	}
 
 	// ------------------
 	// Statements
 	// ------------------
 
+	@Deprecated
 	public static boolean cmp_LE(Context cx, Object val1, Object val2) {
-		double d1, d2;
-		if (val1 instanceof Number && val2 instanceof Number) {
-			d1 = ((Number) val1).doubleValue();
-			d2 = ((Number) val2).doubleValue();
-		} else {
-			if ((val1 instanceof Symbol) || (val2 instanceof Symbol)) {
-				throw typeError0(cx, "msg.compare.symbol");
-			}
-			if (val1 instanceof Scriptable) {
-				val1 = ((Scriptable) val1).getDefaultValue(cx, DefaultValueTypeHint.NUMBER);
-			}
-			if (val2 instanceof Scriptable) {
-				val2 = ((Scriptable) val2).getDefaultValue(cx, DefaultValueTypeHint.NUMBER);
-			}
-			if (val1 instanceof CharSequence && val2 instanceof CharSequence) {
-				return val1.toString().compareTo(val2.toString()) <= 0;
-			}
-			d1 = toNumber(cx, val1);
-			d2 = toNumber(cx, val2);
-		}
-		return d1 <= d2;
+		return compare(cx, val1, val2, Token.LE);
 	}
 
 	public static void initScript(Context cx, Scriptable scope, NativeFunction funObj, Scriptable thisObj, boolean evalScript) {

--- a/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
+++ b/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
@@ -21,6 +21,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -2362,11 +2363,24 @@ public class ScriptRuntime {
 	}
 
 	/**
+	 * @return true if the value is trivially representable in JS,
+	 * i.e. it is either a JS primitive or a Scriptable.
+	 */
+	private static boolean isJSValue(Object obj) {
+		return obj == null || Undefined.isUndefined(obj) || obj instanceof Scriptable || obj instanceof CharSequence || obj instanceof Number || obj instanceof Boolean || obj instanceof Symbol;
+	}
+
+	/**
 	 * Implement "SameValueZero" from ECMA 7.2.9
 	 */
 	public static boolean sameZero(Context cx, Object x, Object y) {
 		x = Wrapper.unwrapped(x);
 		y = Wrapper.unwrapped(y);
+
+		if (!isJSValue(x) || !isJSValue(y)) {
+			// use java equals for java objects
+			return Objects.equals(x, y);
+		}
 
 		if (typeof(cx, x) != typeof(cx, y)) {
 			return false;

--- a/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
+++ b/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
@@ -2621,6 +2621,19 @@ public class ScriptRuntime {
 		return compare(cx, val1, val2, Token.LE);
 	}
 
+	/**
+	 * Adds to the current count of executed instructions and notifies the context's
+	 * instruction observer when the configured threshold is exceeded. Used by long-running
+	 * native loops (such as the regexp engine) so they remain interruptible.
+	 */
+	public static void addInstructionCount(Context cx, int instructionsToAdd) {
+		cx.instructionCount += instructionsToAdd;
+		if (cx.instructionCount > cx.instructionThreshold) {
+			cx.observeInstructionCount(cx.instructionCount);
+			cx.instructionCount = 0;
+		}
+	}
+
 	public static void initScript(Context cx, Scriptable scope, NativeFunction funObj, Scriptable thisObj, boolean evalScript) {
 		if (!cx.hasTopCallScope()) {
 			throw new IllegalStateException();

--- a/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
+++ b/src/main/java/dev/latvian/mods/rhino/ScriptRuntime.java
@@ -2960,25 +2960,27 @@ public class ScriptRuntime {
 		Scriptable object = cx.newObject(scope);
 		for (int i = 0, end = propertyIds.length; i != end; ++i) {
 			Object id = propertyIds[i];
-			int getterSetter = getterSetters == null ? 0 : getterSetters[i];
+			int getterSetter = getterSetters == null ? 0 : getterSetters[i]; // -1 for GET, 1 for SET, 0 for a regular property
 			Object value = propertyValues[i];
-			if (id instanceof String) {
-				if (getterSetter == 0) {
-					if (isSpecialProperty((String) id)) {
-						Ref ref = specialRef(cx, scope, object, (String) id);
+			if (getterSetter == 0) {
+				if (id instanceof String str) {
+					if (isSpecialProperty(str)) {
+						Ref ref = specialRef(cx, scope, object, str);
 						ref.set(cx, scope, value);
 					} else {
-						object.put(cx, (String) id, object, value);
+						object.put(cx, str, object, value);
 					}
 				} else {
-					ScriptableObject so = (ScriptableObject) object;
-					Callable getterOrSetter = (Callable) value;
-					boolean isSetter = getterSetter == 1;
-					so.setGetterOrSetter(cx, (String) id, 0, getterOrSetter, isSetter);
+					int index = (Integer) id;
+					object.put(cx, index, object, value);
 				}
 			} else {
-				int index = (Integer) id;
-				object.put(cx, index, object, value);
+				ScriptableObject so = (ScriptableObject) object;
+				Callable getterOrSetter = (Callable) value;
+				boolean isSetter = getterSetter == 1;
+				String key = id instanceof String ? (String) id : null;
+				int index = key == null ? (Integer) id : 0;
+				so.setGetterOrSetter(cx, key, index, getterOrSetter, isSetter);
 			}
 		}
 		return object;

--- a/src/main/java/dev/latvian/mods/rhino/ScriptableObject.java
+++ b/src/main/java/dev/latvian/mods/rhino/ScriptableObject.java
@@ -805,9 +805,10 @@ public abstract class ScriptableObject implements Scriptable, SymbolScriptable, 
 		return result;
 	}
 
-	private static Scriptable getBase(Scriptable obj, String name, Context cx) {
+	private static Scriptable getBase(Scriptable start, String name, Context cx) {
+		Scriptable obj = start;
 		do {
-			if (obj.has(cx, name, obj)) {
+			if (obj.has(cx, name, start)) {
 				break;
 			}
 			obj = obj.getPrototype(cx);
@@ -815,9 +816,10 @@ public abstract class ScriptableObject implements Scriptable, SymbolScriptable, 
 		return obj;
 	}
 
-	private static Scriptable getBase(Context cx, Scriptable obj, int index) {
+	private static Scriptable getBase(Context cx, Scriptable start, int index) {
+		Scriptable obj = start;
 		do {
-			if (obj.has(cx, index, obj)) {
+			if (obj.has(cx, index, start)) {
 				break;
 			}
 			obj = obj.getPrototype(cx);
@@ -825,9 +827,10 @@ public abstract class ScriptableObject implements Scriptable, SymbolScriptable, 
 		return obj;
 	}
 
-	private static Scriptable getBase(Context cx, Scriptable obj, Symbol key) {
+	private static Scriptable getBase(Context cx, Scriptable start, Symbol key) {
+		Scriptable obj = start;
 		do {
-			if (ensureSymbolScriptable(obj, cx).has(cx, key, obj)) {
+			if (ensureSymbolScriptable(obj, cx).has(cx, key, start)) {
 				break;
 			}
 			obj = obj.getPrototype(cx);

--- a/src/main/java/dev/latvian/mods/rhino/SpecialRef.java
+++ b/src/main/java/dev/latvian/mods/rhino/SpecialRef.java
@@ -83,7 +83,25 @@ class SpecialRef extends Ref {
 						throw ScriptRuntime.typeError0(cx, "msg.not.extensible");
 					}
 
-					if ((value != null && ScriptRuntime.typeof(cx, value) != MemberType.OBJECT) || ScriptRuntime.typeof(cx, target) != MemberType.OBJECT) {
+					MemberType typeOfTarget = ScriptRuntime.typeof(cx, target);
+					if (typeOfTarget == MemberType.FUNCTION) {
+						if (value == null) {
+							target.setPrototype(Undefined.SCRIPTABLE_INSTANCE);
+							return value;
+						}
+
+						MemberType typeOfValue = ScriptRuntime.typeof(cx, value);
+						if (typeOfValue == MemberType.OBJECT || typeOfValue == MemberType.FUNCTION) {
+							target.setPrototype(obj);
+						}
+						return value;
+					}
+
+					if (typeOfTarget == MemberType.SYMBOL) {
+						return value;
+					}
+
+					if ((value != null && ScriptRuntime.typeof(cx, value) != MemberType.OBJECT) || typeOfTarget != MemberType.OBJECT) {
 						return Undefined.INSTANCE;
 					}
 					target.setPrototype(obj);

--- a/src/main/java/dev/latvian/mods/rhino/Undefined.java
+++ b/src/main/java/dev/latvian/mods/rhino/Undefined.java
@@ -100,6 +100,9 @@ public class Undefined {
 
 		@Override
 		public Object getDefaultValue(Context cx, DefaultValueTypeHint hint) {
+			if (hint == null || hint == DefaultValueTypeHint.STRING) {
+				return "undefined";
+			}
 			throw new UnsupportedOperationException("undefined doesn't support getDefaultValue");
 		}
 

--- a/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
+++ b/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
@@ -2263,18 +2263,25 @@ public class NativeRegExp extends IdScriptableObject implements Function {
 	}
 
 	Scriptable compile(Context cx, Scriptable scope, Object[] args) {
-		if (args.length > 0 && args[0] instanceof NativeRegExp thatObj) {
-			if (args.length > 1 && args[1] != Undefined.INSTANCE) {
-				// report error
-				throw ScriptRuntime.typeError0(cx, "msg.bad.regexp.compile");
-			}
+		if (args.length >= 1 && args[0] instanceof NativeRegExp thatObj && (args.length == 1 || args[1] == Undefined.INSTANCE)) {
+			// Avoid recompiling the regex
 			this.re = thatObj.re;
-			setLastIndex(thatObj.lastIndex, cx);
-			return this;
+		} else {
+			String pattern;
+			if (args.length == 0 || args[0] == Undefined.INSTANCE) {
+				pattern = "";
+			} else if (args[0] instanceof NativeRegExp thatObj) {
+				// Passing a regex and flags is allowed in ES6, but was forbidden in ES5 and lower.
+				// Spec ref: 22.2.4.1 in ES6
+				pattern = new String(thatObj.re.source);
+			} else {
+				pattern = escapeRegExp(cx, args[0]);
+			}
+
+			String flags = args.length > 1 && args[1] != Undefined.INSTANCE ? ScriptRuntime.toString(cx, args[1]) : null;
+
+			this.re = compileRE(cx, pattern, flags, false);
 		}
-		String s = args.length == 0 || args[0] instanceof Undefined ? "" : escapeRegExp(cx, args[0]);
-		String global = args.length > 1 && args[1] != Undefined.INSTANCE ? ScriptRuntime.toString(cx, args[1]) : null;
-		this.re = compileRE(cx, s, global, false);
 		setLastIndex(ScriptRuntime.zeroObj, cx);
 		return this;
 	}

--- a/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
+++ b/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
@@ -1773,7 +1773,11 @@ public class NativeRegExp extends IdScriptableObject implements Function {
 			}
 		}
 
+		final boolean instructionCounting = cx.getInstructionObserverThreshold() != 0;
 		for (; ; ) {
+			if (instructionCounting) {
+				ScriptRuntime.addInstructionCount(cx, 5);
+			}
 
 			if (reopIsSimple(op)) {
 				int match = simpleMatch(gData, input, op, program, pc, end, true, cx);

--- a/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
+++ b/src/main/java/dev/latvian/mods/rhino/regexp/NativeRegExp.java
@@ -1995,8 +1995,8 @@ public class NativeRegExp extends IdScriptableObject implements Function {
 								pc += getOffset(program, pc);
 								break switchStatement;
 							}
-							if (state.min == 0 && gData.cp == state.index) {
-								// matched an empty string, that'll get us nowhere
+							if (state.min == 0 && (gData.cp == state.index || state.max == 0)) {
+								// matched an empty string or an {0} quantifier, that'll get us nowhere
 								result = false;
 								continuationPc = state.continuationPc;
 								continuationOp = state.continuationOp;

--- a/src/main/java/dev/latvian/mods/rhino/regexp/RegExp.java
+++ b/src/main/java/dev/latvian/mods/rhino/regexp/RegExp.java
@@ -21,6 +21,7 @@ public class RegExp {
 	public static final int RA_MATCH = 1;
 	public static final int RA_REPLACE = 2;
 	public static final int RA_SEARCH = 3;
+	public static final int RA_REPLACE_ALL = 4;
 
 	private static NativeRegExp createRegExp(Context cx, Scriptable scope, Object[] args, int optarg, boolean forceFlat) {
 		NativeRegExp re;
@@ -70,7 +71,7 @@ public class RegExp {
 				if (data.mode == RA_MATCH) {
 					match_glob(data, cx, scope, count, reImpl);
 				} else {
-					if (data.mode != RA_REPLACE) {
+					if (data.mode != RA_REPLACE && data.mode != RA_REPLACE_ALL) {
 						Kit.codeBug();
 					}
 					SubString lastMatch = reImpl.lastMatch;
@@ -87,7 +88,7 @@ public class RegExp {
 				}
 			}
 		} else {
-			result = re.executeRegExp(cx, scope, reImpl, str, indexp, ((data.mode == RA_REPLACE) ? NativeRegExp.TEST : NativeRegExp.MATCH));
+			result = re.executeRegExp(cx, scope, reImpl, str, indexp, ((data.mode == RA_REPLACE || data.mode == RA_REPLACE_ALL) ? NativeRegExp.TEST : NativeRegExp.MATCH));
 		}
 
 		return result;
@@ -372,12 +373,15 @@ public class RegExp {
 				NativeRegExp re = createRegExp(cx, scope, args, optarg, false);
 				return matchOrReplace(cx, scope, thisObj, args, this, data, re);
 			}
-			case RA_REPLACE -> {
+			case RA_REPLACE, RA_REPLACE_ALL -> {
 				boolean useRE = args.length > 0 && args[0] instanceof NativeRegExp;
 				NativeRegExp re = null;
 				String search = null;
 				if (useRE) {
 					re = createRegExp(cx, scope, args, 2, true);
+					if (RA_REPLACE_ALL == actionType && (re.getFlags() & NativeRegExp.JSREG_GLOB) == 0) {
+						throw ScriptRuntime.typeError(cx, "replaceAll must be called with a global RegExp");
+					}
 				} else {
 					Object arg0 = args.length < 1 ? Undefined.INSTANCE : args[0];
 					search = ScriptRuntime.toString(cx, arg0);
@@ -398,33 +402,55 @@ public class RegExp {
 				data.charBuf = null;
 				data.leftIndex = 0;
 
-				Object val;
 				if (useRE) {
-					val = matchOrReplace(cx, scope, thisObj, args, this, data, re);
+					Object val = matchOrReplace(cx, scope, thisObj, args, this, data, re);
+					if (data.charBuf == null) {
+						if (data.global || val == null || !val.equals(Boolean.TRUE)) {
+							/* Didn't match even once. */
+							return data.str;
+						}
+						SubString lc = this.leftContext;
+						replace_glob(data, cx, scope, this, lc.index, lc.length);
+					}
 				} else {
-					String str = data.str;
-					int index = str.indexOf(search);
-					if (index >= 0) {
-						int slen = search.length();
+					final String str = data.str;
+					final int strLen = str.length();
+					final int searchLen = search.length();
+					int index = -1;
+					int lastIndex = 0;
+					for (; ; ) {
+						if (search.isEmpty()) {
+							if (index == -1) {
+								index = 0;
+							} else {
+								index = (lastIndex < strLen) ? lastIndex + 1 : -1;
+							}
+						} else {
+							index = str.indexOf(search, lastIndex);
+						}
+
+						if (index == -1) {
+							if (data.charBuf == null) {
+								return str;
+							}
+							break;
+						}
+
 						this.parens = null;
 						this.lastParen = null;
 						this.leftContext = new SubString(str, 0, index);
-						this.lastMatch = new SubString(str, index, slen);
-						this.rightContext = new SubString(str, index + slen, str.length() - index - slen);
-						val = Boolean.TRUE;
-					} else {
-						val = Boolean.FALSE;
+						this.lastMatch = new SubString(str, index, searchLen);
+						this.rightContext = new SubString(str, index + searchLen, strLen - index - searchLen);
+
+						replace_glob(data, cx, scope, this, lastIndex, index - lastIndex);
+						lastIndex = index + searchLen;
+
+						if (actionType != RA_REPLACE_ALL) {
+							break;
+						}
 					}
 				}
 
-				if (data.charBuf == null) {
-					if (data.global || val == null || !val.equals(Boolean.TRUE)) {
-						/* Didn't match even once. */
-						return data.str;
-					}
-					SubString lc = this.leftContext;
-					replace_glob(data, cx, scope, this, lc.index, lc.length);
-				}
 				SubString rc = this.rightContext;
 				data.charBuf.append(rc.str, rc.index, rc.index + rc.length);
 				return data.charBuf.toString();

--- a/src/main/resources/dev/latvian/mods/rhino/resources/Messages.properties
+++ b/src/main/resources/dev/latvian/mods/rhino/resources/Messages.properties
@@ -623,3 +623,9 @@ msg.no.new=\
   {0} objects may not be constructed using \"new\"
 msg.map.function.not=\
   Map function is not actually a function
+
+msg.constructor.no.function=\
+  The constructor for {0} may not be invoked as a function
+
+msg.this.not.instance=\
+  "this" is not an instance of the class

--- a/src/test/java/dev/latvian/mods/rhino/test/ArrayObjectTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/ArrayObjectTests.java
@@ -1,0 +1,407 @@
+package dev.latvian.mods.rhino.test;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Tests for array and object-likes.
+ */
+@SuppressWarnings("unused")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ArrayObjectTests {
+	public static final RhinoTest TEST = new RhinoTest("arrays");
+
+	@Test
+	public void arrayAt() {
+		TEST.test("arrayAt", """
+			const a = [5, 12, 8, 130, 44];
+			console.info(a.at(2));
+			console.info(a.at(-2));
+			console.info(a.at(99));
+			console.info(a.at());
+			""", """
+			8
+			130
+			undefined
+			5
+			""");
+	}
+
+	@Test
+	public void arrayCopy() {
+		TEST.test("arrayCopy", """
+			const a = [3, 1, 2];
+			const r = a.toReversed();
+			console.info(r.join(','));
+			console.info(a.join(','));
+			const s = a.toSorted();
+			console.info(s.join(','));
+			const sd = a.toSorted((x, y) => y - x);
+			console.info(sd.join(','));
+			console.info(a.join(','));
+			const sp = [1, 2, 3, 4, 5].toSpliced(1, 2, 'x', 'y', 'z');
+			console.info(sp.join(','));
+			const w = a.with(1, 99);
+			console.info(w.join(','));
+			console.info(a.join(','));
+			const h = [1, , 3].toReversed();
+			console.info(JSON.stringify(h) + ' ' + (1 in h));
+			try {
+				a.with(5, 0);
+			} catch (e) {
+				console.info('range error');
+			}
+			""", """
+			2,1,3
+			3,1,2
+			1,2,3
+			3,2,1
+			3,1,2
+			1,x,y,z,4,5
+			3,99,2
+			3,1,2
+			[3,null,1] true
+			range error
+			""");
+	}
+
+	@Test
+	public void arrayFindLast() {
+		TEST.test("arrayFindLast", """
+			const a = [5, 12, 50, 130, 44];
+			console.info(a.findLast(x => x > 45));
+			console.info(a.findLastIndex(x => x > 45));
+			console.info(a.findLast(x => x > 1000));
+			console.info(a.findLastIndex(x => x > 1000));
+			""", """
+			130
+			3
+			undefined
+			-1
+			""");
+	}
+
+	@Test
+	public void arrayFlat() {
+		TEST.test("arrayFlat", """
+			console.info(JSON.stringify([1, 2, [3, 4]].flat()));
+			console.info(JSON.stringify([1, 2, [3, [4, 5]]].flat()));
+			console.info(JSON.stringify([1, 2, [3, [4, [5, 6]]]].flat(2)));
+			console.info(JSON.stringify([1, 2, [3, [4, [5, [6]]]]].flat(Infinity)));
+			console.info(JSON.stringify([1, 2, , 4, 5].flat()));
+			""", """
+			[1,2,3,4]
+			[1,2,3,[4,5]]
+			[1,2,3,4,[5,6]]
+			[1,2,3,4,5,6]
+			[1,2,4,5]
+			""");
+	}
+
+	@Test
+	public void arrayFlatMap() {
+		TEST.test("arrayFlatMap", """
+			const a = [1, 2, 3, 4];
+			console.info(JSON.stringify(a.flatMap(x => [x, x * 2])));
+			console.info(JSON.stringify(a.flatMap(x => [[x * 2]])));
+			""", """
+			[1,2,2,4,3,6,4,8]
+			[[2],[4],[6],[8]]
+			""");
+	}
+
+	@Test
+	public void arrayFromSparse() {
+		TEST.test("arrayFromSparse", """
+			const a = Array.from([1, , 3]);
+			console.info(1 in a);
+			console.info(a[1]);
+			console.info(JSON.stringify(Array.from([1, , 3], x => typeof x)));
+			""", """
+			true
+			undefined
+			["number","undefined","number"]
+			""");
+	}
+
+	@Test
+	public void numberKeyedObjectValues() {
+		TEST.test("numberKeyedObjectValues", """
+			const obj = { 0: 50, 1: 25, 2: 18, 3: 7 }
+			console.info(Object.keys(obj).join(','))
+			console.info(Object.values(obj).join(','))
+			console.info(Object.entries(obj).map(e => e.join(':')).join(','))
+			""", """
+			0,1,2,3
+			50,25,18,7
+			0:50,1:25,2:18,3:7
+			""");
+	}
+
+	@Test
+	public void objectFromEntries() {
+		TEST.test("objectFromEntries", """
+			const o = Object.fromEntries([['a', 1], ['b', 2]]);
+			console.info(JSON.stringify(o));
+			const m = new Map([['x', 'y']]);
+			console.info(JSON.stringify(Object.fromEntries(m)));
+			const o2 = Object.fromEntries(Object.entries({ q: 7 }));
+			console.info(o2.q);
+			""", """
+			{"a":1,"b":2}
+			{"x":"y"}
+			7
+			""");
+	}
+
+	@Test
+	public void objectGetOwnPropertyDescriptors() {
+		TEST.test("objectGetOwnPropertyDescriptors", """
+			const o = { a: 1 };
+			Object.defineProperty(o, 'b', { value: 2, enumerable: false });
+			const descs = Object.getOwnPropertyDescriptors(o);
+			console.info(descs.a.value);
+			console.info(descs.a.enumerable);
+			console.info(descs.b.value);
+			console.info(descs.b.enumerable);
+			""", """
+			1
+			true
+			2
+			false
+			""");
+	}
+
+	@Test
+	public void objectGroupBy() {
+		TEST.test("objectGroupBy", """
+			const inventory = [
+				{ name: 'asparagus', type: 'vegetables', quantity: 5 },
+				{ name: 'bananas', type: 'fruit', quantity: 0 },
+				{ name: 'goat', type: 'meat', quantity: 23 },
+				{ name: 'cherries', type: 'fruit', quantity: 5 }
+			];
+			const byType = Object.groupBy(inventory, i => i.type);
+			console.info(Object.keys(byType).join(','));
+			console.info(byType.fruit.map(i => i.name).join(','));
+			console.info(Object.getPrototypeOf(byType));
+			const byIndex = Object.groupBy([10, 20], (v, i) => i);
+			console.info(byIndex[0][0] + ',' + byIndex[1][0]);
+			try {
+				Object.groupBy([1], 'nope');
+			} catch (e) {
+				console.info('type error');
+			}
+			""", """
+			vegetables,fruit,meat
+			bananas,cherries
+			null
+			10,20
+			type error
+			""");
+	}
+
+	@Test
+	public void objectHasOwn() {
+		TEST.test("objectHasOwn", """
+			const o = { a: 1 };
+			console.info(Object.hasOwn(o, 'a'));
+			console.info(Object.hasOwn(o, 'b'));
+			console.info(Object.hasOwn(o, 'toString'));
+			console.info(Object.hasOwn([1, 2], 1));
+			console.info(Object.hasOwn([1, 2], 5));
+			""", """
+			true
+			false
+			false
+			true
+			false
+			""");
+	}
+
+	@Test
+	public void jsonStringifyNumbers() {
+		TEST.test("jsonStringifyNumbers", """
+			console.info(JSON.stringify(50.0))
+			console.info(JSON.stringify(1.5))
+			console.info(JSON.stringify({ a: 1, b: 2.5 }))
+			console.info(JSON.stringify([1, 2, 3]))
+			console.info(JSON.stringify({ a: Infinity, b: NaN, c: 1/0 }))
+			""", """
+			50
+			1.5
+			{"a":1,"b":2.5}
+			[1,2,3]
+			{"a":null,"b":null,"c":null}
+			""");
+	}
+
+	@Test
+	public void jsonStringifySpecial() {
+		TEST.test("jsonStringifySpecial", """
+			console.info(JSON.stringify(undefined))
+			console.info(JSON.stringify(function () {}))
+			console.info(JSON.stringify(Symbol('x')))
+			console.info(JSON.stringify({ a: null, b: undefined, c: () => 4, d: 'ok' }))
+			console.info(JSON.stringify([1, undefined, () => 4, 2]))
+			""", """
+			undefined
+			undefined
+			undefined
+			{"a":null,"d":"ok"}
+			[1,null,null,2]
+			""");
+	}
+
+	@Test
+	public void jsonStringifyWithNestedArrays() {
+		TEST.test("jsonStringifyWithNestedArrays", """
+			const thing = {nested: [1, 2, 3]};
+			console.info(JSON.stringify(thing));
+			""", "{\"nested\":[1,2,3]}");
+	}
+
+	@Test
+	@Order(1)
+	public void javaListInit() {
+		TEST.test("javaListInit", """
+			const testObject = {
+				a: -39, b: 2, c: 3439438
+			}
+			
+			let testList = console.testList
+			
+			for (let string of testList) {
+				console.info(string)
+			}
+			
+			shared.testObject = testObject
+			shared.testList = testList
+			""", """
+			abc
+			def
+			ghi
+			""");
+	}
+
+	@Test
+	@Order(2)
+	public void javaListLength() {
+		TEST.test("javaListLength", """
+			console.info('init ' + shared.testList.length)
+			shared.testList.add('abcawidawidaiwdjawd')
+			console.info('add ' + shared.testList.length)
+			shared.testList.push('abcawidawidaiwdjawd')
+			console.info('push ' + shared.testList.length)
+			""", """
+			init 3
+			add 4
+			push 5
+			""");
+	}
+
+	@Test
+	@Order(3)
+	public void javaListPopShiftMap() {
+		TEST.test("javaListPopShiftMap", """
+			console.info('pop ' + shared.testList.pop() + ' ' + shared.testList.length)
+			console.info('shift ' + shared.testList.shift() + ' ' + shared.testList.length)
+			console.info('map ' + shared.testList.concat(['xyz']).reverse().map(e => e.toUpperCase()).join(" | "))
+			""", """
+			pop abcawidawidaiwdjawd 4
+			shift abc 3
+			map XYZ | ABCAWIDAWIDAIWDJAWD | GHI | DEF
+			""");
+	}
+
+	@Test
+	@Order(4)
+	public void keysValuesEntries() {
+		TEST.test("keysValuesEntries", """
+			console.info(Object.keys(shared.testObject))
+			console.info(Object.values(shared.testObject))
+			console.info(Object.entries(shared.testObject))
+			""", """
+			['a', 'b', 'c']
+			[-39, 2, 3439438]
+			[['a', -39], ['b', 2], ['c', 3439438]]
+			""");
+	}
+
+	@Test
+	@Order(5)
+	public void deconstruction() {
+		TEST.test("deconstruction", """
+			for (let [key, value] of Object.entries(shared.testObject)) {
+				console.info(`${key} : ${value}`)
+			}
+			""", """
+			a : -39
+			b : 2
+			c : 3439438
+			""");
+	}
+
+	@Test
+	@Order(6)
+	public void javaArrayIteration() {
+		TEST.test("javaArrayIteration", """
+			for (let x of console.testArray) {
+				console.info(x)
+			}
+			""", """
+			abc
+			def
+			ghi
+			""");
+	}
+
+	@Test
+	public void functionNameLengthConfigurable() {
+		TEST.test("functionNameLengthConfigurable", """
+			function foo(a, b) {}
+			console.info(foo.name + ' ' + foo.length);
+			const nameDesc = Object.getOwnPropertyDescriptor(foo, 'name');
+			console.info(nameDesc.configurable + ' ' + nameDesc.writable + ' ' + nameDesc.enumerable);
+			const lenDesc = Object.getOwnPropertyDescriptor(foo, 'length');
+			console.info(lenDesc.configurable + ' ' + lenDesc.writable + ' ' + lenDesc.enumerable);
+			delete foo.name;
+			console.info('[' + foo.name + ']');
+			delete foo.length;
+			// after deletion the inherited Function.prototype.length (0) shows through
+			console.info(foo.length);
+			const protoDesc = Object.getOwnPropertyDescriptor(Function.prototype, 'name');
+			console.info(protoDesc.configurable);
+			""", """
+			foo 2
+			true false false
+			true false false
+			[]
+			0
+			true
+			""");
+	}
+
+	@Test
+	public void indexedAccessorInLiteral() {
+		TEST.test("indexedAccessorInLiteral", """
+			const o = {
+				get 0() { return 'zero'; },
+				get x() { return 'ex'; }
+			};
+			console.info(o[0]);
+			console.info(o.x);
+			let captured = null;
+			const o2 = { set 1(v) { captured = v; } };
+			o2[1] = 'one';
+			console.info(captured);
+			""", """
+			zero
+			ex
+			one
+			""");
+	}
+
+}

--- a/src/test/java/dev/latvian/mods/rhino/test/CollectionTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/CollectionTests.java
@@ -1,0 +1,61 @@
+package dev.latvian.mods.rhino.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests for Map and Set.
+ */
+@SuppressWarnings("unused")
+public class CollectionTests {
+	public static class TestUtil {
+		public static UUID one() {
+			return new UUID(0L, 1L);
+		}
+	}
+
+	public static final RhinoTest TEST = new RhinoTest("collections").withScopeAction((cx, rootScope) -> {
+		cx.addToScope(rootScope, "TestUtil", TestUtil.class);
+	});
+
+	@Test
+	public void jsCollectionsJavaObjectId() {
+		TEST.test("jsCollectionsJavaObjectId", """
+			const s = new Set();
+			s.add(TestUtil.one());
+			s.add(TestUtil.one());
+			console.info(s.size);
+			console.info(s.has(TestUtil.one()));
+			const m = new Map();
+			m.set(TestUtil.one(), 'first');
+			m.set(TestUtil.one(), 'second');
+			console.info(m.size);
+			console.info(m.get(TestUtil.one()));
+			""", """
+			1
+			true
+			1
+			second
+			""");
+	}
+
+	@Test
+	public void mapGroupBy() {
+		TEST.test("mapGroupBy", """
+			const m = Map.groupBy([1, 2, 3, 4, 5], x => x % 2 === 0 ? 'even' : 'odd');
+			console.info(m instanceof Map);
+			console.info(m.size);
+			console.info(m.get('odd').join(','));
+			console.info(m.get('even').join(','));
+			const z = Map.groupBy([7], () => -0);
+			console.info(1 / z.keys().next().value);
+			""", """
+			true
+			2
+			1,3,5
+			2,4
+			Infinity
+			""");
+	}
+}

--- a/src/test/java/dev/latvian/mods/rhino/test/GenericsTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/GenericsTests.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.reflect.Modifier;
+
 @SuppressWarnings("unused")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class GenericsTests {
@@ -99,5 +101,17 @@ public class GenericsTests {
 			""", """
 			hi
 			""");
+	}
+
+	@Test
+	public void types() {
+		for (var method : GenericObject.class.getDeclaredMethods()) {
+			if (!Modifier.isStatic(method.getModifiers())) {
+				GenericObject.test = method.getName();
+				GenericObject.test(method.getName(), method.getGenericReturnType());
+			}
+		}
+
+		GenericObject.test = "";
 	}
 }

--- a/src/test/java/dev/latvian/mods/rhino/test/InteropTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/InteropTests.java
@@ -1,0 +1,86 @@
+package dev.latvian.mods.rhino.test;
+
+import dev.latvian.mods.rhino.JavaScriptException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests for features and fixes in the Java-JS interop layer.
+ */
+@SuppressWarnings("unused")
+public class InteropTests {
+	public static class TestUtil {
+		public static UUID one() {
+			return new UUID(0L, 1L);
+		}
+
+		public static void boom() {
+			throw new IllegalStateException("kaBOOM");
+		}
+	}
+
+	public static class InterfaceTests {
+		public interface Defaulted {
+			default String someMethod() {
+				return "default";
+			}
+		}
+
+		public interface DefaultedAbstract {
+			String abstractMethod();
+
+			default String someMethod() {
+				return "default";
+			}
+		}
+
+		public static String callDefaulted(Defaulted d) {
+			return d.someMethod();
+		}
+
+		public static String callDefaultedAbstract(DefaultedAbstract d) {
+			return d.someMethod() + "," + d.abstractMethod();
+		}
+	}
+
+	public static final RhinoTest TEST = new RhinoTest("interopLayer").withScopeAction((cx, rootScope) -> {
+		cx.addToScope(rootScope, "TestUtil", TestUtil.class);
+		cx.addToScope(rootScope, "Interfaces", InterfaceTests.class);
+	});
+
+
+
+	@Test
+	public void javaScriptExceptionPreservesCause() {
+		var factory = new TestContextFactory();
+		var cx = factory.enter();
+		var scope = cx.initStandardObjects();
+		cx.addToScope(scope, "TestUtil", TestUtil.class);
+		try {
+			cx.evaluateString(scope, "try { TestUtil.boom(); } catch (e) { throw e; }", "causeTest", 1, null);
+			Assertions.fail("expected an exception");
+		} catch (JavaScriptException ex) {
+			Throwable cause = ex.getCause();
+			while (cause != null && !(cause instanceof IllegalStateException)) {
+				cause = cause.getCause();
+			}
+			Assertions.assertNotNull(cause, "IllegalStateException not in cause chain??");
+			Assertions.assertEquals("kaBOOM", cause.getMessage());
+		}
+	}
+
+	@Test
+	public void overriddenDefaultMethod() {
+		TEST.test("overriddenDefaultMethod", """
+			console.info(Interfaces.callDefaulted({}))
+			console.info(Interfaces.callDefaulted({ someMethod: () => 'overridden' }))
+			console.info(Interfaces.callDefaultedAbstract({ someMethod: () => 'overridden', abstractMethod: () => 'js abstract' }))
+			""", """
+			default
+			overridden
+			overridden,js abstract
+			""");
+	}
+}

--- a/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/MiscTests.java
@@ -1,95 +1,13 @@
 package dev.latvian.mods.rhino.test;
 
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-
-import java.lang.reflect.Modifier;
 
 @SuppressWarnings("unused")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MiscTests {
-	public static class InterfaceTests {
-		public interface Defaulted {
-			default String someMethod() {
-				return "default";
-			}
-		}
-
-		public interface DefaultedAbstract {
-			String abstractMethod();
-
-			default String someMethod() {
-				return "default";
-			}
-		}
-
-		public static String callDefaulted(Defaulted d) {
-			return d.someMethod();
-		}
-
-		public static String callDefaultedAbstract(DefaultedAbstract d) {
-			return d.someMethod() + "," + d.abstractMethod();
-		}
-	}
-
-	public static final RhinoTest TEST = new RhinoTest("misc").withScopeAction(((cx, rootScope) -> {
-		cx.addToScope(rootScope, "Interfaces", InterfaceTests.class);
-	}));
-
-	@Test
-	public void testFunctionAssignment() {
-		TEST.test("functionAssignment",
-			"""
-				let x = () => {};
-				x.abc = 1;
-				console.info(x.abc);
-				""",
-			"1"
-		);
-	}
-
-	@Test
-	public void testDelete() {
-		TEST.test("delete", "let x = {a: 1}; delete x.a; console.info(x.a);", "undefined");
-	}
-
-	@Test
-	@Order(1)
-	public void init() {
-		TEST.test("init", """
-			const testObject = {
-				a: -39, b: 2, c: 3439438
-			}
-			
-			let testList = console.testList
-			
-			for (let string of testList) {
-				console.info(string)
-			}
-			
-			shared.testObject = testObject
-			shared.testList = testList
-			""", """
-			abc
-			def
-			ghi
-			""");
-	}
-
-	@Test
-	public void array() {
-		TEST.test("array", """
-			for (let x of console.testArray) {
-				console.info(x)
-			}
-			""", """
-			abc
-			def
-			ghi
-			""");
-	}
+	public static final RhinoTest TEST = new RhinoTest("misc");
 
 	@Test
 	public void enums() {
@@ -103,130 +21,124 @@ public class MiscTests {
 	}
 
 	@Test
-	@Order(2)
-	public void arrayLength() {
-		TEST.test("arrayLength", """
-			console.info('init ' + shared.testList.length)
-			shared.testList.add('abcawidawidaiwdjawd')
-			console.info('add ' + shared.testList.length)
-			shared.testList.push('abcawidawidaiwdjawd')
-			console.info('push ' + shared.testList.length)
+	public void errorCause() {
+		TEST.test("errorCause", """
+			const e = new Error('msg', { cause: 'root' });
+			console.info(e.cause);
+			console.info(e.message);
+			const e2 = new Error('msg2');
+			console.info('cause' in e2);
+			const e3 = new TypeError('bad', { cause: 42 });
+			console.info(e3.cause);
+			const e4 = new Error('m', { cause: undefined });
+			console.info('cause' in e4);
 			""", """
-			init 3
-			add 4
-			push 5
+			root
+			msg
+			false
+			42
+			true
 			""");
 	}
 
 	@Test
-	@Order(3)
-	public void popUnshiftMap() {
-		TEST.test("popUnshiftMap", """
-			console.info('pop ' + shared.testList.pop() + ' ' + shared.testList.length)
-			console.info('shift ' + shared.testList.shift() + ' ' + shared.testList.length)
-			console.info('map ' + shared.testList.concat(['xyz']).reverse().map(e => e.toUpperCase()).join(" | "))
+	public void errorIsError() {
+		TEST.test("errorIsError", """
+			console.info(Error.isError(new Error('x')));
+			console.info(Error.isError(new TypeError('x')));
+			console.info(Error.isError({ name: 'Error', message: 'x' }));
+			console.info(Error.isError('Error'));
+			console.info(Error.isError());
+			console.info(Error.isError(null));
 			""", """
-			pop abcawidawidaiwdjawd 4
-			shift abc 3
-			map XYZ | ABCAWIDAWIDAIWDJAWD | GHI | DEF
+			true
+			true
+			false
+			false
+			false
+			false
 			""");
 	}
 
 	@Test
-	@Order(4)
-	public void keysValuesEntries() {
-		TEST.test("keysValuesEntries", """
-			console.info(Object.keys(shared.testObject))
-			console.info(Object.values(shared.testObject))
-			console.info(Object.entries(shared.testObject))
+	public void functionAssign() {
+		TEST.test("functionAssign", """
+			let x = () => {};
+			x.abc = 1;
+			console.info(x.abc);
+			""", "1");
+	}
+
+	@Test
+	public void functionProto() {
+		TEST.test("functionProto", """
+			function F() {}
+			const p = { x: 1 };
+			F.__proto__ = p;
+			console.info(F.x);
+			const o = {};
+			o.__proto__ = { y: 2 };
+			console.info(o.y);
 			""", """
-			['a', 'b', 'c']
-			[-39, 2, 3439438]
-			[['a', -39], ['b', 2], ['c', 3439438]]
+			1
+			2
 			""");
 	}
 
 	@Test
-	public void numberKeyedObjectValues() {
-		TEST.test("numberKeyedObjectValues", """
-			const obj = { 0: 50, 1: 25, 2: 18, 3: 7 }
-			console.info(Object.keys(obj).join(','))
-			console.info(Object.values(obj).join(','))
-			console.info(Object.entries(obj).map(e => e.join(':')).join(','))
+	public void get() {
+		TEST.test("get", """
+			console.info(console.immutableInt)
 			""", """
-			0,1,2,3
-			50,25,18,7
-			0:50,1:25,2:18,3:7
+			40
 			""");
 	}
 
 	@Test
-	@Order(4)
-	public void deconstruction() {
-		TEST.test("deconstruction", """
-			for (let [key, value] of Object.entries(shared.testObject)) {
-				console.info(`${key} : ${value}`)
-			}
+	public void set() {
+		TEST.test("set", """
+			console.mutableInt = 30.5
+			console.info(console.mutableInt)
 			""", """
-			a : -39
-			b : 2
-			c : 3439438
+			30
 			""");
 	}
 
 	@Test
-	@Order(4)
-	public void typeWrappers() {
-		TEST.test("typeWrappers", """
-			console.printMaterial('wood')
-			console.printMaterial('stone')
-			console.printMaterial('wood')
-			""", """
-			wood#0037c6ad
-			stone#068af865
-			wood#0037c6ad
-			""");
+	public void testDelete() {
+		TEST.test("delete", "let x = {a: 1}; delete x.a; console.info(x.a);", "undefined");
 	}
 
 	@Test
-	public void jsonStringifyNumbers() {
-		TEST.test("jsonStringifyNumbers", """
-			console.info(JSON.stringify(50.0))
-			console.info(JSON.stringify(1.5))
-			console.info(JSON.stringify({ a: 1, b: 2.5 }))
-			console.info(JSON.stringify([1, 2, 3]))
-			console.info(JSON.stringify({ a: Infinity, b: NaN, c: 1/0 }))
+	public void mathF16round() {
+		TEST.test("mathF16round", """
+			console.info(Math.f16round(5.5));
+			console.info(Math.f16round(5.05));
+			console.info(Math.f16round(0.1));
+			console.info(Math.f16round(NaN));
+			console.info(Math.f16round(Infinity));
+			console.info(Math.f16round(-Infinity));
+			console.info(1 / Math.f16round(-0));
+			console.info(Math.f16round(65520));
+			console.info(Math.f16round(65519.999));
+			console.info(Math.f16round(5.960464477539063e-8));
+			console.info(Math.f16round(2.980232238769531e-8));
+			console.info(Math.f16round(1.337));
+			console.info(Math.f16round());
 			""", """
-			50
-			1.5
-			{"a":1,"b":2.5}
-			[1,2,3]
-			{"a":null,"b":null,"c":null}
-			""");
-	}
-
-	@Test
-	public void jsonStringifyWithNestedArrays() {
-		TEST.test("jsonStringifyWithNestedArrays", """
-			const thing = {nested: [1, 2, 3]};
-			console.info(JSON.stringify(thing));
-			""", "{\"nested\":[1,2,3]}");
-	}
-
-	@Test
-	public void jsonStringifySpecial() {
-		TEST.test("jsonStringifyUnserializable", """
-			console.info(JSON.stringify(undefined))
-			console.info(JSON.stringify(function () {}))
-			console.info(JSON.stringify(Symbol('x')))
-			console.info(JSON.stringify({ a: null, b: undefined, c: () => 4, d: 'ok' }))
-			console.info(JSON.stringify([1, undefined, () => 4, 2]))
-			""", """
-			undefined
-			undefined
-			undefined
-			{"a":null,"d":"ok"}
-			[1,null,null,2]
+			5.5
+			5.05078125
+			0.0999755859375
+			NaN
+			Infinity
+			-Infinity
+			-Infinity
+			Infinity
+			65504
+			5.960464477539063e-8
+			0
+			1.3369140625
+			NaN
 			""");
 	}
 
@@ -250,44 +162,6 @@ public class MiscTests {
 	}
 
 	@Test
-	public void types() {
-		for (var method : GenericObject.class.getDeclaredMethods()) {
-			if (!Modifier.isStatic(method.getModifiers())) {
-				GenericObject.test = method.getName();
-				GenericObject.test(method.getName(), method.getGenericReturnType());
-			}
-		}
-
-		GenericObject.test = "";
-	}
-
-	@Test
-	public void varargs() {
-		TEST.test("varargs", """
-			console.varargTest("hi", 1, 2, 3);
-			""", "VarArg Ints hi: [1, 2, 3]");
-	}
-
-	@Test
-	public void get() {
-		TEST.test("get", """
-			console.info(console.immutableInt)
-			""", """
-			40
-			""");
-	}
-
-	@Test
-	public void set() {
-		TEST.test("set", """
-			console.mutableInt = 30.5
-			console.info(console.mutableInt)
-			""", """
-			30
-			""");
-	}
-
-	@Test
 	public void privateInnerClassAccess() {
 		TEST.test("privateInnerClassAccess", """
 			console.info(console.immutableTestList.size())
@@ -303,15 +177,22 @@ public class MiscTests {
 	}
 
 	@Test
-	public void overriddenDefaultMethod() {
-		TEST.test("overriddenDefaultMethod", """
-			console.info(Interfaces.callDefaulted({}))
-			console.info(Interfaces.callDefaulted({ someMethod: () => 'overridden' }))
-			console.info(Interfaces.callDefaultedAbstract({ someMethod: () => 'overridden', abstractMethod: () => 'js abstract' }))
+	public void typeWrappers() {
+		TEST.test("typeWrappers", """
+			console.printMaterial('wood')
+			console.printMaterial('stone')
+			console.printMaterial('wood')
 			""", """
-			default
-			overridden
-			overridden,js abstract
+			wood#0037c6ad
+			stone#068af865
+			wood#0037c6ad
 			""");
+	}
+
+	@Test
+	public void varargs() {
+		TEST.test("varargs", """
+			console.varargTest("hi", 1, 2, 3);
+			""", "VarArg Ints hi: [1, 2, 3]");
 	}
 }

--- a/src/test/java/dev/latvian/mods/rhino/test/StringTests.java
+++ b/src/test/java/dev/latvian/mods/rhino/test/StringTests.java
@@ -1,0 +1,70 @@
+package dev.latvian.mods.rhino.test;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for String and RegExp.
+ */
+@SuppressWarnings("unused")
+public class StringTests {
+	public static final RhinoTest TEST = new RhinoTest("strings");
+
+	@Test
+	public void stringAt() {
+		TEST.test("stringAt", """
+			const s = 'abcde';
+			console.info(s.at(0));
+			console.info(s.at(-1));
+			console.info(s.at(10));
+			""", """
+			a
+			e
+			undefined
+			""");
+	}
+
+	@Test
+	public void stringReplaceAll() {
+		TEST.test("stringReplaceAll", """
+			console.info('aabbcc'.replaceAll('b', '.'));
+			console.info('aabbcc'.replaceAll('', '-'));
+			console.info('aabbcc'.replaceAll(/b/g, '.'));
+			console.info('x=1, y=2'.replaceAll(/(\\w)=(\\d)/g, '$2:$1'));
+			console.info('aabbcc'.replaceAll('b', m => m.toUpperCase()));
+			try {
+				'aabbcc'.replaceAll(/b/, '.');
+			} catch (e) {
+				console.info('type error');
+			}
+			""", """
+			aa..cc
+			-a-a-b-b-c-c-
+			aa..cc
+			1:x, 2:y
+			aaBBcc
+			type error
+			""");
+	}
+
+	@Test
+	public void regexpConstructorWithFlags() {
+		TEST.test("regexpConstructorWithFlags", """
+			const base = /ab+c/g;
+			const re = new RegExp(base, 'i');
+			console.info(re.source);
+			console.info(re.global);
+			console.info(re.ignoreCase);
+			console.info(re.test('ABBC'));
+			const copy = new RegExp(base);
+			console.info(copy.source + ' ' + copy.global);
+			console.info(new RegExp(/x/m, undefined).multiline);
+			""", """
+			ab+c
+			false
+			true
+			true
+			ab+c true
+			true
+			""");
+	}
+}


### PR DESCRIPTION
This is a whole host of changes made to upstream Rhino that we never got to merge into our version since we hard-forked in 2020.

This was also what I originally intended to use Claude for yesterday, i.e. it'd go through the commit history and take what would be easiest to port from upstream. Of course, all of these commits had to be cherrypicked and adjusted from the patch still since we both have a different package than upstream and also do some stuff differently in general (like passing Context as a param everywhere); but in general, each of these changes should be as close to verbatim to the original version as possible.

I also decided to shuffle some tests around because testing for regressions with the stuff we just added is never a bad idea
